### PR TITLE
Fix alignment of U+2192, U+2198, U+2199 in Mono

### DIFF
--- a/sources/libertinusmono-regular.sfd
+++ b/sources/libertinusmono-regular.sfd
@@ -4,21 +4,24 @@ FullName: Libertinus Mono
 FamilyName: Libertinus Mono
 Weight: Regular
 Copyright: 
-UComments: "2003-08-29: Created.+AAoA-2004-07-25: v(1.0) release candidate+AAoA-2005-12-28: v(1.1.0)stable+AAoA-2006-05-01: v(2.0.0)stable+AAoA-2007-01-10: v(2.3.0)stable" 
+UComments: "2003-08-29: Created.+AAoA-2004-07-25: v(1.0) release candidate+AAoA-2005-12-28: v(1.1.0)stable+AAoA-2006-05-01: v(2.0.0)stable+AAoA-2007-01-10: v(2.3.0)stable"
 Version: 5.1.7
 ItalicAngle: 0
 UnderlinePosition: -98
 UnderlineWidth: 40
 Ascent: 754
 Descent: 246
+InvalidEm: 0
 LayerCount: 2
-Layer: 0 0 "Back"  1
-Layer: 1 0 "Fore"  0
+Layer: 0 0 "Back" 1
+Layer: 1 0 "Fore" 0
 XUID: [1021 975 16237491 13016554]
 FSType: 0
+OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 1
 CreationTime: 1155510122
+ModificationTime: 1510454923
 PfmFamily: 49
 TTFWeight: 400
 TTFWidth: 5
@@ -39,32 +42,32 @@ HheadDescent: -246
 HheadDOffset: 0
 OS2FamilyClass: 261
 OS2Vendor: 'PfEd'
-Lookup: 1 0 0 "Substitution dotless forms"  {"Substitution dotless forms 1"  } []
-Lookup: 1 0 0 "'locl' Localized Forms Cyrillic"  {"'locl' Localized Forms Cyrillic-1"  } ['locl' ('cyrl' <'SRB ' > ) ]
-Lookup: 1 0 0 "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc"  {"'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc"  } ['smcp' ('latn' <'AZE ' 'CRT ' 'TRK ' > ) ]
-Lookup: 1 0 0 "'smcp' Gemeine nach Kapitaelchen"  {"'smcp' Gemeine nach Kapitaelchen 1"  } ['smcp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'smcp' Gemeine nach Kapitaelchen i > i.sc"  {"'smcp' Gemeine nach Kapitaelchen i > i.sc 1"  } ['smcp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'dflt' > ) ]
-Lookup: 4 0 0 "'frac' Brueche"  {"'frac' Brueche 1"  } ['frac' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'case' Versalformen"  {"'case' Versalformen 1"  } ['case' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'sups' Hochgestellte"  {"'sups' Hochgestellte 1" ("superior" ) } ['sups' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'sinf' Tiefgestellte"  {"'sinf' Wissenschaftliche Indices 1" ("inferior" ) } ['sinf' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'c2sc' Versale nach Kapitaelchen"  {"'c2sc' Versale nach Kapitaelchen 1" ("sc" ) } ['c2sc' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'lnum' Versalziffern"  {"'lnum' Versalziffern 1"  } ['lnum' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'tnum' Tabellenziffern"  {"'tnum' Tabellenziffern 1"  } ['tnum' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'pnum' Proportionalziffern"  {"'pnum' Proportionalziffern 1"  } ['pnum' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'onum' Minuskelziffern"  {"'onum' Minuskelziffern 1" ("oldstyle" ) } ['onum' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'zero' gestrichene Null"  {"'zero' gestrichene Null 1"  } ['zero' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'salt' Stilistische Alternativformen"  {"'salt' Stilistische Alternativformen 1"  } ['salt' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'ss01' Stilgruppe 1"  {"'ss01' Stilgruppe 1 1"  } ['ss01' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'ss02' Stilgruppe 2"  {"'ss02' Stilgruppe 2 1"  } ['ss02' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'ss03' Stilgruppe 3"  {"'ss03' Stilgruppe 3 1"  } ['ss03' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'fina' Wortendeformen"  {"'fina' Wortendeformen 1"  } ['fina' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 6 0 0 "'ccmp' Contextual Chaining Substitution"  {"'ccmp' Contextual Chaining Substitution 1"  } ['ccmp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 1 0 0 "'nalt' Alternate Annotation Forms lookup 0"  {"'nalt' Alternate Annotation Forms 1"  } ['nalt' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
-Lookup: 260 0 0 "'mark' Markenpositionierung"  {"'mark' Komb OR"  "'mark' Top rechts"  "'mark' Top Akzent"  "'mark' Mittelpunkt"  "'mark' Ogonek"  "'mark' Unten Anhang"  "'mark' Unten Punkt"  "'mark' Top Punkt2"  } ['mark' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "Substitution dotless forms" { "Substitution dotless forms 1"  } []
+Lookup: 1 0 0 "'locl' Localized Forms Cyrillic" { "'locl' Localized Forms Cyrillic-1"  } ['locl' ('cyrl' <'SRB ' > ) ]
+Lookup: 1 0 0 "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" { "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc"  } ['smcp' ('latn' <'AZE ' 'CRT ' 'TRK ' > ) ]
+Lookup: 1 0 0 "'smcp' Gemeine nach Kapitaelchen" { "'smcp' Gemeine nach Kapitaelchen 1"  } ['smcp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'smcp' Gemeine nach Kapitaelchen i > i.sc" { "'smcp' Gemeine nach Kapitaelchen i > i.sc 1"  } ['smcp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'dflt' > ) ]
+Lookup: 4 0 0 "'frac' Brueche" { "'frac' Brueche 1"  } ['frac' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'case' Versalformen" { "'case' Versalformen 1"  } ['case' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'sups' Hochgestellte" { "'sups' Hochgestellte 1" ("superior") } ['sups' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'sinf' Tiefgestellte" { "'sinf' Wissenschaftliche Indices 1" ("inferior") } ['sinf' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'c2sc' Versale nach Kapitaelchen" { "'c2sc' Versale nach Kapitaelchen 1" ("sc") } ['c2sc' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'lnum' Versalziffern" { "'lnum' Versalziffern 1"  } ['lnum' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'tnum' Tabellenziffern" { "'tnum' Tabellenziffern 1"  } ['tnum' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'pnum' Proportionalziffern" { "'pnum' Proportionalziffern 1"  } ['pnum' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'onum' Minuskelziffern" { "'onum' Minuskelziffern 1" ("oldstyle") } ['onum' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'zero' gestrichene Null" { "'zero' gestrichene Null 1"  } ['zero' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'salt' Stilistische Alternativformen" { "'salt' Stilistische Alternativformen 1"  } ['salt' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'ss01' Stilgruppe 1" { "'ss01' Stilgruppe 1 1"  } ['ss01' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'ss02' Stilgruppe 2" { "'ss02' Stilgruppe 2 1"  } ['ss02' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'ss03' Stilgruppe 3" { "'ss03' Stilgruppe 3 1"  } ['ss03' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'fina' Wortendeformen" { "'fina' Wortendeformen 1"  } ['fina' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 6 0 0 "'ccmp' Contextual Chaining Substitution" { "'ccmp' Contextual Chaining Substitution 1"  } ['ccmp' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 1 0 0 "'nalt' Alternate Annotation Forms lookup 0" { "'nalt' Alternate Annotation Forms 1"  } ['nalt' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'hebr' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
+Lookup: 260 0 0 "'mark' Markenpositionierung" { "'mark' Komb OR"  "'mark' Top rechts"  "'mark' Top Akzent"  "'mark' Mittelpunkt"  "'mark' Ogonek"  "'mark' Unten Anhang"  "'mark' Unten Punkt"  "'mark' Top Punkt2"  } ['mark' ('DFLT' <'dflt' > 'cyrl' <'dflt' > 'grek' <'dflt' > 'latn' <'AZE ' 'CRT ' 'TRK ' 'dflt' > ) ]
 MarkAttachClasses: 1
 DEI: 91125
-ChainSub2: class "'ccmp' Contextual Chaining Substitution 1"  5 1 5 2
+ChainSub2: class "'ccmp' Contextual Chaining Substitution 1" 5 1 5 2
   Class: 3 i j
   Class: 323 gravecomb acutecomb uni0302 tildecomb uni0304 uni0305 uni0306 uni0307 uni0308 hookabovecomb uni030A uni030B uni030C uni030D uni030E uni030F uni0310 uni0311 uni0312 uni0313 uni0314 uni0315 uni031A uni0351 uni0357 uni0358 uniE358 uni0359 uni035A uni035B uniE35C uni035D uni035E uni035F uni0360 uni0361 uni0362 uni0363 uniE364
   Class: 5 f f_f
@@ -78,24 +81,28 @@ ChainSub2: class "'ccmp' Contextual Chaining Substitution 1"  5 1 5 2
   BClsList:
   FClsList: 2
  1
-  SeqLookup: 0 "Substitution dotless forms" 
+  SeqLookup: 0 "Substitution dotless forms"
  1 0 1
   ClsList: 3
   BClsList:
   FClsList: 4
  0
-  ClassNames: "0"  "1"  "2"  "3"  "4"  
-  BClassNames: "0"  
-  FClassNames: "0"  "1"  "2"  "3"  "4"  
+  ClassNames: "0" "1" "2" "3" "4"
+  BClassNames: "0"
+  FClassNames: "0" "1" "2" "3" "4"
 EndFPST
 ShortTable: cvt  2
   68
   1297
 EndShort
-LangName: 1033 "" "" "" "" "" "" "" "" "Philipp H. Poll" "Philipp H. Poll" "" "http://www.linuxlibertine.org" "http://www.linuxlibertine.org" "GPL - General Public License AND OFL - Open Font License" "http://www.fsf.org/licenses/gpl.html AND http://scripts.sil.org/OFL" 
+LangName: 1033 "" "" "" "" "" "" "" "" "Philipp H. Poll" "Philipp H. Poll" "" "http://www.linuxlibertine.org" "http://www.linuxlibertine.org" "GPL - General Public License AND OFL - Open Font License" "http://www.fsf.org/licenses/gpl.html AND http://scripts.sil.org/OFL"
 Encoding: UnicodeBmp
 UnicodeInterp: none
 NameList: AGL For New Fonts
+DisplaySize: -48
+AntiAlias: 1
+FitToEm: 0
+WinInfo: 8550 38 14
 BeginPrivate: 10
 BlueValues 31 [-12 0 480 490 613 626 688 698]
 OtherBlues 11 [-238 -227]
@@ -110,16 +117,16 @@ StemSnapV 4 [87]
 EndPrivate
 Grid
 -1000 480 m 0
- 2000 480 l 0
-  Named: "Courier-x-H+APYA-he" 
+ 2000 480 l 1024
+  Named: "Courier-x-H+APYA-he"
 -1000 1152 m 0
- 2000 1152 l 0
+ 2000 1152 l 1024
 59.333 52 m 25
- 524.667 52 l 25
+ 524.667 52 l 1049
 86 436 m 25
- 432 436 l 25
+ 432 436 l 1049
 -392 -319 m 25
- 400 -319 l 25
+ 400 -319 l 1049
 367 -341 m 2
  122 -341 l 2
  114 -341 110 -333 110 -326 c 0
@@ -128,7 +135,7 @@ Grid
  386 -297 390 -304 390 -311 c 0
  390 -323 380 -341 367 -341 c 2
 -92.5 1254 m 0
- -92.5 -746 l 0
+ -92.5 -746 l 1024
 714 850 m 25
  93 850 l 25
  714 850 l 25
@@ -140,20 +147,20 @@ Grid
  386 -87 390 -94 390 -101 c 0
  390 -113 380 -131 367 -131 c 2
 -1000 480 m 0
- 2000 480 l 0
+ 2000 480 l 1024
 -1000 -233 m 0
- 2000 -233 l 0
+ 2000 -233 l 1024
 -1000 613 m 0
- 2000 613 l 0
+ 2000 613 l 1024
 -1000 698 m 0
- 2000 698 l 0
+ 2000 698 l 1024
 71 -67 m 25
  424 -67 l 25
  423 -163 l 25
  70 -163 l 25
  71 -67 l 25
 -7 625 m 1
- 693 625 l 1
+ 693 625 l 1025
 952 615 m 1
  954 613 l 1
  954 586 l 2
@@ -165,18 +172,18 @@ Grid
  8 613 l 1
  10 615 l 1
  952 615 l 1
-801 647 m 25
+801 647 m 1049
 -261 -141 m 25
- 905 -141 l 25
+ 905 -141 l 1049
 905 -128 m 25
  -261 -128 l 25
  905 -128 l 25
 60 658 m 25
- 584 658 l 25
+ 584 658 l 1049
 -57 -10 m 17
- 1009 -10 l 9
+ 1009 -10 l 1033
 -42 490 m 1
- 658 490 l 1
+ 658 490 l 1025
 637 482 m 1
  639 480 l 1
  639 453 l 2
@@ -200,7 +207,7 @@ Grid
  14 35 l 2
  55 35 932 35 972 35 c 2
 552 647 m 25
- 943 647 l 25
+ 943 647 l 1049
 863 894 m 25
  82 894 l 25
  77 893 l 25
@@ -208,12 +215,12 @@ Grid
  75 885 l 25
  78 883 l 25
  81 883 l 25
- 84 884 l 25
+ 84 884 l 1049
 732 805 m 25
  -265 805 l 25
  732 805 l 25
 67 -110 m 25
- 379 -110 l 25
+ 379 -110 l 1049
 0 608 m 25
  0 604 l 25
  0 608 l 25
@@ -223,7 +230,7 @@ Grid
  430 608 l 25
  439 608 l 25
  439 606 l 25
- 439 608 l 25
+ 439 608 l 1049
 -246 615 m 25
  683 615 l 25
  683 0 l 17
@@ -236,9 +243,9 @@ Grid
  236 550 l 1
  213 506 l 1
  193 550 l 1
- -463 550 l 1
+ -463 550 l 1025
 EndSplineSet
-AnchorClass2: "top_rechts"  "'mark' Top rechts" "top_punkt2"  "'mark' Top Punkt2" "unten_punkt"  "'mark' Unten Punkt" "unten_anhang"  "'mark' Unten Anhang" "ogonek"  "'mark' Ogonek" "mittelpunkt"  "'mark' Mittelpunkt" "top_akzent"  "'mark' Top Akzent" "komb_OR"  "'mark' Komb OR" 
+AnchorClass2: "top_rechts" "'mark' Top rechts" "top_punkt2" "'mark' Top Punkt2" "unten_punkt" "'mark' Unten Punkt" "unten_anhang" "'mark' Unten Anhang" "ogonek" "'mark' Ogonek" "mittelpunkt" "'mark' Mittelpunkt" "top_akzent" "'mark' Top Akzent" "komb_OR" "'mark' Komb OR"
 BeginChars: 65537 1018
 
 StartChar: exclam
@@ -2791,7 +2798,7 @@ SplineSet
  201 229 195 227 190 213 c 2
  145 79 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E01
@@ -2831,7 +2838,7 @@ SplineSet
  611 33.6 569 -10 493 -10 c 0
  424 -10 412 21 407 55 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E02
@@ -2869,7 +2876,7 @@ SplineSet
  37 584 37 609 43 615 c 1
  81.7 614 121.7 613 172 613 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E03
@@ -2904,7 +2911,7 @@ SplineSet
  190 456 l 2
  190 436 198.7 434.4 206 440 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E04
@@ -2942,7 +2949,7 @@ SplineSet
  37 584 37 609 43 615 c 1
  81.7 614 121.7 613 172 613 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E05
@@ -2977,7 +2984,7 @@ SplineSet
  190 456 l 2
  190 436 198.7 434.4 206 440 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E06
@@ -3022,7 +3029,7 @@ SplineSet
  372 -87 376 -94 376 -101 c 0
  376 -113 366 -131 353 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E07
@@ -3064,7 +3071,7 @@ SplineSet
  362 -87 366 -94 366 -101 c 0
  366 -113 356 -131 343 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E08
@@ -3099,7 +3106,7 @@ SplineSet
  357 -171 378 -157 378 -131 c 0
  378 -110 368 -96 345 -96 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E09
@@ -3145,7 +3152,7 @@ SplineSet
  -1 556.2 2.3 560.2 10.4 573 c 2
  86 692 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E0A
@@ -3174,7 +3181,7 @@ SplineSet
  13 584 13 609 19 615 c 1
  65 614 92.8 613 140 613 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E0B
@@ -3214,7 +3221,7 @@ SplineSet
  454 -10 443 28 443 55 c 0
  443 63 435 60 430 56 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E0C
@@ -3243,7 +3250,7 @@ SplineSet
  13 584 13 609 19 615 c 1
  65 614 92.8 613 140 613 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E0D
@@ -3283,7 +3290,7 @@ SplineSet
  454 -10 443 28 443 55 c 0
  443 63 435 60 430 56 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E0E
@@ -3319,7 +3326,7 @@ SplineSet
  399 -87 403 -94 403 -101 c 0
  403 -113 393 -131 380 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E0F
@@ -3366,7 +3373,7 @@ SplineSet
  350 -87 354 -94 354 -101 c 0
  354 -113 344 -131 331 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E10
@@ -3408,7 +3415,7 @@ SplineSet
  13 584 13 609 19 615 c 1
  65 614 92.8 613 140 613 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E11
@@ -3462,7 +3469,7 @@ SplineSet
  45 -171 66 -157 66 -131 c 0
  66 -110 56 -96 33 -96 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E12
@@ -3491,7 +3498,7 @@ SplineSet
  13 584 13 609 19 615 c 1
  65 614 92.8 613 140 613 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E13
@@ -3531,7 +3538,7 @@ SplineSet
  454 -10 443 28 443 55 c 0
  443 63 435 60 430 56 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E14
@@ -3582,7 +3589,7 @@ SplineSet
  215 343 l 1
  323 343 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E15
@@ -3676,7 +3683,7 @@ SplineSet
  215 343 l 1
  323 343 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E17
@@ -3763,7 +3770,7 @@ SplineSet
  215 343 l 1
  323 343 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E19
@@ -3791,7 +3798,7 @@ SplineSet
  252 62 312.8 40 377 40 c 0
  452 40 504 66 551 109 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E1A
@@ -3835,7 +3842,7 @@ SplineSet
  215 343 l 1
  323 343 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E1B
@@ -3863,7 +3870,7 @@ SplineSet
  252 62 312.8 40 377 40 c 0
  452 40 504 66 551 109 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E1C
@@ -3928,7 +3935,7 @@ SplineSet
  483 227 462 227 456 233 c 1
  453 276 459 297 375 297 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E1F
@@ -3969,7 +3976,7 @@ SplineSet
  290 396 l 1
  290 126 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E20
@@ -4000,7 +4007,7 @@ SplineSet
  155 -10 35 112 35 292 c 0
  35 538 197 625 359 625 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E21
@@ -4048,7 +4055,7 @@ SplineSet
  561 516 582 498 582 475 c 0
  582 453 562 433 541 433 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E22
@@ -4092,7 +4099,7 @@ SplineSet
  551 574 548 569 548 495 c 2
  548 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E23
@@ -4134,7 +4141,7 @@ SplineSet
  320 434 256 396.3 218 359 c 0
  210 350.3 201 338 201 316.9 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E24
@@ -4178,7 +4185,7 @@ SplineSet
  551 574 548 569 548 495 c 2
  548 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E25
@@ -4220,7 +4227,7 @@ SplineSet
  320 434 256 396.3 218 359 c 0
  210 350.3 201 338 201 316.9 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E26
@@ -4274,7 +4281,7 @@ SplineSet
  551 574 548 569 548 495 c 2
  548 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E27
@@ -4326,7 +4333,7 @@ SplineSet
  320 434 256 396.3 218 359 c 0
  210 350.3 201 338 201 316.9 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E28
@@ -4384,7 +4391,7 @@ SplineSet
  551 574 548 569 548 495 c 2
  548 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E29
@@ -4440,7 +4447,7 @@ SplineSet
  -30 -171 -9 -157 -9 -131 c 0
  -9 -110 -19 -96 -42 -96 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E2A
@@ -4484,7 +4491,7 @@ SplineSet
  551 574 548 569 548 495 c 2
  548 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E2B
@@ -4526,7 +4533,7 @@ SplineSet
  320 434 256 396.3 218 359 c 0
  210 350.3 201 338 201 316.9 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E2C
@@ -4552,7 +4559,7 @@ SplineSet
  379 574 374 568 374 491 c 2
  374 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E2D
@@ -4586,7 +4593,7 @@ SplineSet
  394 456.5 380 439.8 380 372 c 2
  380 134 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E2E
@@ -4627,7 +4634,7 @@ SplineSet
  164.1 801.9 165.6 806.3 175.6 814.2 c 2
  271.1 889.9 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E2F
@@ -4675,7 +4682,7 @@ SplineSet
  32.2 639.1 34.7 642.5 41 653.8 c 2
  99.2 758.5 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E30
@@ -4729,7 +4736,7 @@ SplineSet
  270 719 272 724 285 733 c 2
  409 819 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E31
@@ -4788,7 +4795,7 @@ SplineSet
  60.4 673.2 123.9 681.4 165.4 689.5 c 1
  167 692 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E32
@@ -4835,7 +4842,7 @@ SplineSet
  264 291 245 298 201 298 c 1
  201 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E33
@@ -4882,7 +4889,7 @@ SplineSet
  48 4 48 29 54 35 c 1
  110 39 121 49 121 132 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E34
@@ -4936,7 +4943,7 @@ SplineSet
  455 -87 459 -94 459 -101 c 0
  459 -113 449 -131 436 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E35
@@ -4990,7 +4997,7 @@ SplineSet
  379 -87 383 -94 383 -101 c 0
  383 -113 373 -131 360 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E36
@@ -5020,7 +5027,7 @@ SplineSet
  564 -2 472 0 445 0 c 2
  197 0 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E37
@@ -5048,7 +5055,7 @@ SplineSet
  116.7 36.3 258 44 269 52 c 0
  283 63 286.5 81.7 286.5 129 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E38
@@ -5078,7 +5085,7 @@ SplineSet
  564 -2 472 0 445 0 c 2
  197 0 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E39
@@ -5106,7 +5113,7 @@ SplineSet
  116.7 36.3 258 44 269 52 c 0
  283 63 286.5 81.7 286.5 129 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E3A
@@ -5143,7 +5150,7 @@ SplineSet
  387 -87 391 -94 391 -101 c 0
  391 -113 381 -131 368 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E3B
@@ -5178,7 +5185,7 @@ SplineSet
  116.7 36.3 258 44 269 52 c 0
  283 63 286.5 81.7 286.5 129 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E3C
@@ -5208,7 +5215,7 @@ SplineSet
  564 -2 472 0 445 0 c 2
  197 0 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E3D
@@ -5236,7 +5243,7 @@ SplineSet
  116.7 36.3 258 44 269 52 c 0
  283 63 286.5 81.7 286.5 129 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E3E
@@ -5286,7 +5293,7 @@ SplineSet
  325 719 327 724 340 733 c 2
  464 819 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E3F
@@ -5342,7 +5349,7 @@ SplineSet
  178 556.2 181.3 560.2 189.4 573 c 2
  265 692 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E40
@@ -5431,7 +5438,7 @@ SplineSet
  160.6 379 150 358 150 337 c 2
  150 132 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E42
@@ -5474,7 +5481,7 @@ SplineSet
  405 4 405 29 411 35 c 1
  481 40 486 44 485 116 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E43
@@ -5521,7 +5528,7 @@ SplineSet
  160.6 379 150 358 150 337 c 2
  150 132 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E44
@@ -5600,7 +5607,7 @@ SplineSet
  199.7 474.7 203 450.1 203 389 c 0
  203 375 209 385 212 389 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E46
@@ -5639,7 +5646,7 @@ SplineSet
  500 150 505 161 505 179 c 2
  505 481 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E47
@@ -5680,7 +5687,7 @@ SplineSet
  199.7 474.7 203 450.1 203 389 c 0
  203 375 209 385 212 389 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E48
@@ -5726,7 +5733,7 @@ SplineSet
  472 -87 476 -94 476 -101 c 0
  476 -113 466 -131 453 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E49
@@ -5774,7 +5781,7 @@ SplineSet
  378 -87 382 -94 382 -101 c 0
  382 -113 372 -131 359 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E4A
@@ -5813,7 +5820,7 @@ SplineSet
  500 150 505 161 505 179 c 2
  505 481 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E4B
@@ -5854,7 +5861,7 @@ SplineSet
  199.7 474.7 203 450.1 203 389 c 0
  203 375 209 385 212 389 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E4C
@@ -5884,7 +5891,7 @@ SplineSet
  149 585 228 625 318 625 c 0
  481 625 606 507 606 313 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E4D
@@ -5927,7 +5934,7 @@ SplineSet
  210 625 233.5 606.9 252 591 c 0
  266.3 578.7 285 572 304 572 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E4E
@@ -5960,7 +5967,7 @@ SplineSet
  149 585 228 625 318 625 c 0
  481 625 606 507 606 313 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E4F
@@ -6004,7 +6011,7 @@ SplineSet
  140 625 163.5 606.9 182 591 c 0
  196.3 578.7 215 572 234 572 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E50
@@ -6034,7 +6041,7 @@ SplineSet
  149 585 228 625 318 625 c 0
  481 625 606 507 606 313 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E51
@@ -6073,7 +6080,7 @@ SplineSet
  19.1 763.3 36.8 778.3 63 778.3 c 0
  66.8 778.3 71.4 777.4 74.5 776.5 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E52
@@ -6103,7 +6110,7 @@ SplineSet
  149 585 228 625 318 625 c 0
  481 625 606 507 606 313 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E53
@@ -6142,7 +6149,7 @@ SplineSet
  98.2 666.1 100.7 669.5 107 680.8 c 2
  165.2 785.5 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E54
@@ -6182,7 +6189,7 @@ SplineSet
  205 719 207 724 220 733 c 2
  344 819 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E55
@@ -6229,7 +6236,7 @@ SplineSet
  86 556.2 89.3 560.2 97.4 573 c 2
  173 692 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E56
@@ -6262,7 +6269,7 @@ SplineSet
  119 38 146 43 146 122 c 2
  146 491 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E57
@@ -6300,7 +6307,7 @@ SplineSet
  185 494 187 490 189 485 c 0
  194 473 195 434 195 401 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E58
@@ -6340,7 +6347,7 @@ SplineSet
  315 262 277 276 193 276 c 1
  193 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E59
@@ -6376,7 +6383,7 @@ SplineSet
  289 493 291 490 293 485 c 0
  298 475 301 460.5 301 406 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E5A
@@ -6416,7 +6423,7 @@ SplineSet
  315 262 277 276 193 276 c 1
  193 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E5B
@@ -6452,7 +6459,7 @@ SplineSet
  289 493 291 490 293 485 c 0
  298 475 301 460.5 301 406 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E5C
@@ -6492,7 +6499,7 @@ SplineSet
  315 262 277 276 193 276 c 1
  193 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E5D
@@ -6528,7 +6535,7 @@ SplineSet
  289 493 291 490 293 485 c 0
  298 475 301 460.5 301 406 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E5E
@@ -6575,7 +6582,7 @@ SplineSet
  432 -87 436 -94 436 -101 c 0
  436 -113 426 -131 413 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E5F
@@ -6618,7 +6625,7 @@ SplineSet
  303 -87 307 -94 307 -101 c 0
  307 -113 297 -131 284 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E60
@@ -6647,7 +6654,7 @@ SplineSet
  90 578 200 625 323 625 c 0
  441 625 441 607 511 599 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E61
@@ -6678,7 +6685,7 @@ SplineSet
  151 5 135 3 123 1 c 1
  105 42 92 89 88 144 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E62
@@ -6707,7 +6714,7 @@ SplineSet
  90 578 200 625 323 625 c 0
  441 625 441 607 511 599 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E63
@@ -6738,7 +6745,7 @@ SplineSet
  151 5 135 3 123 1 c 1
  105 42 92 89 88 144 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E64
@@ -6779,7 +6786,7 @@ SplineSet
  36 788 9 757 -22 757 c 0
  -49 757 -76 787 -76 817 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E65
@@ -6819,7 +6826,7 @@ SplineSet
  151 5 135 3 123 1 c 1
  105 42 92 89 88 144 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E66
@@ -6861,7 +6868,7 @@ SplineSet
  154 862 127 831 96 831 c 0
  69 831 42 861 42 891 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E67
@@ -6900,7 +6907,7 @@ SplineSet
  151 5 135 3 123 1 c 1
  105 42 92 89 88 144 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E68
@@ -6929,7 +6936,7 @@ SplineSet
  90 578 200 625 323 625 c 0
  441 625 441 607 511 599 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E69
@@ -6960,7 +6967,7 @@ SplineSet
  151 5 135 3 123 1 c 1
  105 42 92 89 88 144 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E6A
@@ -6995,7 +7002,7 @@ SplineSet
  377 576 367 540 367 479 c 2
  367 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E6B
@@ -7064,7 +7071,7 @@ SplineSet
  377 576 367 540 367 479 c 2
  367 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E6D
@@ -7099,7 +7106,7 @@ SplineSet
  71 420 l 2
  71 428 75 440 89 440 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E6E
@@ -7141,7 +7148,7 @@ SplineSet
  416 -87 420 -94 420 -101 c 0
  420 -113 410 -131 397 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E6F
@@ -7183,7 +7190,7 @@ SplineSet
  288.5 -87 292.5 -94 292.5 -101 c 0
  292.5 -113 282.5 -131 269.5 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E70
@@ -7295,7 +7302,7 @@ SplineSet
  463 -88 442 -109 416 -109 c 0
  390 -109 369 -88 369 -62 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E73
@@ -7347,7 +7354,7 @@ SplineSet
  374.1 -88 353.1 -109 327.1 -109 c 0
  301.1 -109 280.1 -88 280.1 -62 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E74
@@ -7380,7 +7387,7 @@ SplineSet
  259 609 259 586 253 580 c 1
  179 577 173 572 173 493 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E75
@@ -7421,7 +7428,7 @@ SplineSet
  439.5 66 432.6 63.9 427.5 60 c 0
  360 9.1 285.5 -10 246.5 -10 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E76
@@ -7454,7 +7461,7 @@ SplineSet
  259 609 259 586 253 580 c 1
  179 577 173 572 173 493 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E77
@@ -7495,7 +7502,7 @@ SplineSet
  439.5 66 432.6 63.9 427.5 60 c 0
  360 9.1 285.5 -10 246.5 -10 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E78
@@ -7546,7 +7553,7 @@ SplineSet
  325.7 826.5 345.7 806.6 361.4 789.1 c 0
  373.6 775.5 389.5 768.2 405.6 768.2 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E79
@@ -7607,7 +7614,7 @@ SplineSet
  137.2 677.1 139.7 680.5 146 691.8 c 2
  204.2 796.5 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: space
@@ -10608,7 +10615,7 @@ SplineSet
  431.5 -75 430.5 -60 435.5 -52 c 1
  475.5 -50 488.5 -47 488.5 -6 c 2
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one slash four
 EndChar
 
@@ -10656,7 +10663,7 @@ SplineSet
  436.5 185.7 441.6 172.9 440.3 165 c 0
  437.3 147 419.7 141.7 409.7 141.7 c 0
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one slash two
 EndChar
 
@@ -10716,7 +10723,7 @@ SplineSet
  126.6 476.5 127.3 487.9 130 497 c 1
  174 503 201 529 201 570 c 0
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three slash four
 EndChar
 
@@ -12921,7 +12928,7 @@ SplineSet
  439.5 66 432.6 63.9 427.5 60 c 0
  360 9.1 285.5 -10 246.5 -10 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: yacute
@@ -14006,7 +14013,7 @@ SplineSet
  266 621 239 590 208 590 c 0
  181 590 154 620 154 650 c 0
 EndSplineSet
-LCarets2: 1 309 
+LCarets2: 1 309
 EndChar
 
 StartChar: Jcircumflex
@@ -17499,7 +17506,7 @@ SplineSet
  259 609 259 586 253 580 c 1
  179 577 173 572 173 493 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E7B
@@ -17557,7 +17564,7 @@ SplineSet
  574 707 553 686 527 686 c 0
  501 686 480 707 480 733 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E7C
@@ -17618,7 +17625,7 @@ SplineSet
  478 382 l 2
  501 433 483 441 424 445 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E7E
@@ -17649,7 +17656,7 @@ SplineSet
  491 502 l 2
  511 553 512 573 438 578 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E7F
@@ -17680,7 +17687,7 @@ SplineSet
  478 382 l 2
  501 433 483 441 424 445 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: Wgrave
@@ -17774,7 +17781,7 @@ SplineSet
  67 677 90 694 124 694 c 0
  129 694 135 693 139 692 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: Wacute
@@ -17820,7 +17827,7 @@ SplineSet
  371 719 373 724 386 733 c 2
  510 819 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: wacute
@@ -17869,7 +17876,7 @@ SplineSet
  121 556.2 124.3 560.2 132.4 573 c 2
  208 692 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: Wdieresis
@@ -17918,7 +17925,7 @@ SplineSet
  775 781 754 760 728 760 c 0
  702 760 681 781 681 807 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: wdieresis
@@ -17968,7 +17975,7 @@ SplineSet
  640 596 619 575 593 575 c 0
  567 575 546 596 546 622 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E86
@@ -18007,7 +18014,7 @@ SplineSet
  295 414 l 1
  359 429 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E87
@@ -18047,7 +18054,7 @@ SplineSet
  308 349 l 1
  358.5 357 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E88
@@ -18086,7 +18093,7 @@ SplineSet
  295 414 l 1
  359 429 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E89
@@ -18126,7 +18133,7 @@ SplineSet
  308 349 l 1
  358.5 357 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E8A
@@ -18225,7 +18232,7 @@ SplineSet
  273 476 273 451 267 445 c 1
  220 439 206 434 225 409 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E8C
@@ -18344,7 +18351,7 @@ SplineSet
  273 476 273 451 267 445 c 1
  220 439 206 434 225 409 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E8E
@@ -18419,7 +18426,7 @@ SplineSet
  475 273 404 119 318 -74 c 0
  305 -104 291 -132 274 -160 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E90
@@ -18462,7 +18469,7 @@ SplineSet
  241 739 274 774 305 808 c 1
  319 816.4 328.6 815.7 344 808 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E91
@@ -18494,7 +18501,7 @@ SplineSet
  92 408.5 100 436 115 484 c 0
  115 486.4 118.6 490 121 490 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E92
@@ -18529,7 +18536,7 @@ SplineSet
  560 162 571 159 578 157 c 1
  566 108 556 51 551 -2 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E93
@@ -18561,7 +18568,7 @@ SplineSet
  92 408.5 100 436 115 484 c 0
  115 486.4 118.6 490 121 490 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E94
@@ -18641,7 +18648,7 @@ SplineSet
  346 -87 350 -94 350 -101 c 0
  350 -113 340 -131 327 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E96
@@ -18690,7 +18697,7 @@ SplineSet
  379 -87 383 -94 383 -101 c 0
  383 -113 373 -131 360 -131 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E97
@@ -18784,7 +18791,7 @@ SplineSet
  388 519 348 479 300 479 c 0
  254 479 212 518 212 564 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E99
@@ -18830,7 +18837,7 @@ SplineSet
  250 510 267 535 267 563 c 0
  267 594 249 616 219 616 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1E9B
@@ -18899,7 +18906,7 @@ SplineSet
  201 229 195 227 190 213 c 2
  145 79 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EA1
@@ -18939,7 +18946,7 @@ SplineSet
  611 33.6 569 -10 493 -10 c 0
  424 -10 412 21 407 55 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EA2
@@ -18990,7 +18997,7 @@ SplineSet
  279 781 307 815 361 815 c 0
  425 815 440 775 440 759 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EA3
@@ -19044,7 +19051,7 @@ SplineSet
  136 673 169 708 211 708 c 0
  266 708 282 667 282 650 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EA4
@@ -19096,7 +19103,7 @@ SplineSet
  458.8 783.4 460.2 787.4 469.3 794.6 c 2
  556.1 863.4 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EA5
@@ -19150,7 +19157,7 @@ SplineSet
  199.9 599.6 217.7 620 235.2 641.2 c 1
  284.6 730.2 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EA6
@@ -19202,7 +19209,7 @@ SplineSet
  113.9 826.8 l 1
  126.7 841 143.2 853.5 167.1 862.8 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EA7
@@ -19259,7 +19266,7 @@ SplineSet
  -85.3 718.2 -69.2 731.8 -45.4 731.8 c 0
  -41.9 731.8 -37.7 731 -34.9 730.2 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EA8
@@ -19318,7 +19325,7 @@ SplineSet
  439 837 467 871 521 871 c 0
  585 871 600 831 600 815 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EA9
@@ -19381,7 +19388,7 @@ SplineSet
  311 756 314 750 314 742 c 0
  314 733.9 306.8 726.3 299.5 722.9 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EAA
@@ -19426,7 +19433,7 @@ SplineSet
  274 713 307 748 338 782 c 1
  352 790.4 361.6 789.7 377 782 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EAB
@@ -19474,7 +19481,7 @@ SplineSet
  611 33.6 569 -10 493 -10 c 0
  424 -10 412 21 407 55 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EAC
@@ -19519,7 +19526,7 @@ SplineSet
  274 738 307 773 338 807 c 1
  352 815.4 361.6 814.7 377 807 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EAD
@@ -19559,7 +19566,7 @@ SplineSet
  611 33.6 569 -10 493 -10 c 0
  424 -10 412 21 407 55 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EAE
@@ -19610,7 +19617,7 @@ SplineSet
  444.6 804 l 1
  454 804 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EAF
@@ -19665,7 +19672,7 @@ SplineSet
  106.2 639.1 108.7 642.5 115 653.8 c 2
  173.2 758.5 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EB0
@@ -19714,7 +19721,7 @@ SplineSet
  425.6 810.4 428.6 807.2 430.4 804 c 1
  454 804 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EB1
@@ -19770,7 +19777,7 @@ SplineSet
  13.1 754.3 30.8 769.3 57 769.3 c 0
  60.8 769.3 65.4 768.4 68.5 767.5 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EB2
@@ -19828,7 +19835,7 @@ SplineSet
  407.1 770.8 415.8 779.5 421.1 789.7 c 1
  410.7 782.4 401.7 774.7 396.3 763.8 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EB3
@@ -19891,7 +19898,7 @@ SplineSet
  133 766 166 801 208 801 c 0
  263 801 279 760 279 743 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EB4
@@ -19935,7 +19942,7 @@ SplineSet
  407 724 459 746 466 785 c 1
  494 785 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EB5
@@ -19982,7 +19989,7 @@ SplineSet
  611 33.6 569 -10 493 -10 c 0
  424 -10 412 21 407 55 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EB6
@@ -20108,7 +20115,7 @@ SplineSet
  215 343 l 1
  323 343 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EB9
@@ -20136,7 +20143,7 @@ SplineSet
  252 62 312.8 40 377 40 c 0
  452 40 504 66 551 109 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EBA
@@ -20194,7 +20201,7 @@ SplineSet
  216 781 244 815 298 815 c 0
  362 815 377 775 377 759 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EBB
@@ -20236,7 +20243,7 @@ SplineSet
  112 673 145 708 187 708 c 0
  242 708 258 667 258 650 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EBC
@@ -20365,7 +20372,7 @@ SplineSet
  397.8 781.4 399.2 785.4 408.3 792.6 c 2
  495.1 861.4 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EBF
@@ -20465,7 +20472,7 @@ SplineSet
  50.9 826.8 l 1
  63.7 841 80.2 853.5 104.1 862.8 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EC1
@@ -20510,7 +20517,7 @@ SplineSet
  -92.3 718.2 -76.2 731.8 -52.4 731.8 c 0
  -48.9 731.8 -44.7 731 -41.9 730.2 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EC2
@@ -20576,7 +20583,7 @@ SplineSet
  176 739 209 774 240 808 c 1
  254 816.4 263.6 815.7 279 808 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EC3
@@ -20625,7 +20632,7 @@ SplineSet
  242 770 275 805 317 805 c 0
  372 805 388 764 388 747 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EC4
@@ -20712,7 +20719,7 @@ SplineSet
  252 62 312.8 40 377 40 c 0
  452 40 504 66 551 109 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EC6
@@ -20791,7 +20798,7 @@ SplineSet
  252 62 312.8 40 377 40 c 0
  452 40 504 66 551 109 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EC8
@@ -20831,7 +20838,7 @@ SplineSet
  69 781 97 815 151 815 c 0
  215 815 230 775 230 759 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EC9
@@ -20874,7 +20881,7 @@ SplineSet
  32 673 65 708 107 708 c 0
  162 708 178 667 178 650 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ECA
@@ -20900,7 +20907,7 @@ SplineSet
  379 574 374 568 374 491 c 2
  374 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ECB
@@ -20934,7 +20941,7 @@ SplineSet
  394 456.5 380 439.8 380 372 c 2
  380 134 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ECC
@@ -20957,7 +20964,7 @@ SplineSet
  149 585 228 625 318 625 c 0
  481 625 606 507 606 313 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ECD
@@ -20980,7 +20987,7 @@ SplineSet
  400 31 484 60 484 203 c 0
  484 367 415 449 301 449 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ECE
@@ -21017,7 +21024,7 @@ SplineSet
  263 805 291 839 345 839 c 0
  409 839 424 799 424 783 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ECF
@@ -21054,7 +21061,7 @@ SplineSet
  113 673 146 708 188 708 c 0
  243 708 259 667 259 650 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ED0
@@ -21092,7 +21099,7 @@ SplineSet
  443.8 776.4 445.2 780.4 454.3 787.6 c 2
  541.1 856.4 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ED1
@@ -21129,7 +21136,7 @@ SplineSet
  219.9 599.6 237.7 620 255.2 641.2 c 1
  304.6 730.2 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ED2
@@ -21167,7 +21174,7 @@ SplineSet
  104.9 828.8 l 1
  117.7 843 134.2 855.5 158.1 864.8 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ED3
@@ -21251,7 +21258,7 @@ SplineSet
  417 841 445 875 499 875 c 0
  563 875 578 835 578 819 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ED5
@@ -21295,7 +21302,7 @@ SplineSet
  254 770 287 805 329 805 c 0
  384 805 400 764 400 747 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ED6
@@ -21356,7 +21363,7 @@ SplineSet
  400 31 484 60 484 203 c 0
  484 367 415 449 301 449 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1ED8
@@ -21409,7 +21416,7 @@ SplineSet
  400 31 484 60 484 203 c 0
  484 367 415 449 301 449 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EDA
@@ -21427,7 +21434,7 @@ SplineSet
  258 720 260 725 273 734 c 2
  397 820 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EDB
@@ -21447,7 +21454,7 @@ SplineSet
  50 556.2 53.3 560.2 61.4 573 c 2
  137 692 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EDC
@@ -21465,7 +21472,7 @@ SplineSet
  215 772 l 1
  233.3 789.7 256.8 805.4 291 817 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EDD
@@ -21485,7 +21492,7 @@ SplineSet
  -48 677 -25 694 9 694 c 0
  14 694 20 693 24 692 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EDE
@@ -21510,7 +21517,7 @@ SplineSet
  277 781 305 815 359 815 c 0
  423 815 438 775 438 759 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EDF
@@ -21535,7 +21542,7 @@ SplineSet
  108 673 141 708 183 708 c 0
  238 708 254 667 254 650 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EE0
@@ -21543,7 +21550,7 @@ Encoding: 7904 7904 550
 Width: 698
 Flags: HMW
 LayerCount: 2
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EE1
@@ -21551,7 +21558,7 @@ Encoding: 7905 7905 551
 Width: 492
 Flags: HMW
 LayerCount: 2
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EE2
@@ -21559,7 +21566,7 @@ Encoding: 7906 7906 552
 Width: 698
 Flags: HMW
 LayerCount: 2
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EE3
@@ -21567,7 +21574,7 @@ Encoding: 7907 7907 553
 Width: 492
 Flags: HMW
 LayerCount: 2
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EE4
@@ -21600,7 +21607,7 @@ SplineSet
  259 609 259 586 253 580 c 1
  179 577 173 572 173 493 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EE5
@@ -21641,7 +21648,7 @@ SplineSet
  439.5 66 432.6 63.9 427.5 60 c 0
  360 9.1 285.5 -10 246.5 -10 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EE6
@@ -21688,7 +21695,7 @@ SplineSet
  263 781 291 815 345 815 c 0
  409 815 424 775 424 759 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EE7
@@ -21743,7 +21750,7 @@ SplineSet
  146 673 179 708 221 708 c 0
  276 708 292 667 292 650 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EE8
@@ -21761,7 +21768,7 @@ SplineSet
  268 720 270 725 283 734 c 2
  407 820 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EE9
@@ -21781,7 +21788,7 @@ SplineSet
  48 556.2 51.3 560.2 59.4 573 c 2
  135 692 l 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EEA
@@ -21799,7 +21806,7 @@ SplineSet
  212 773 l 1
  230.3 790.7 253.8 806.4 288 818 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EEB
@@ -21819,7 +21826,7 @@ SplineSet
  -39 677 -16 694 18 694 c 0
  23 694 29 693 33 692 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EEC
@@ -21844,7 +21851,7 @@ SplineSet
  265 781 293 815 347 815 c 0
  411 815 426 775 426 759 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EED
@@ -21869,7 +21876,7 @@ SplineSet
  156 673 189 708 231 708 c 0
  286 708 302 667 302 650 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EEE
@@ -21877,7 +21884,7 @@ Encoding: 7918 7918 564
 Width: 699
 Flags: HMW
 LayerCount: 2
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EEF
@@ -21885,7 +21892,7 @@ Encoding: 7919 7919 565
 Width: 549
 Flags: HMW
 LayerCount: 2
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EF0
@@ -21893,7 +21900,7 @@ Encoding: 7920 7920 566
 Width: 699
 Flags: HMW
 LayerCount: 2
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EF1
@@ -21901,7 +21908,7 @@ Encoding: 7921 7921 567
 Width: 549
 Flags: HMW
 LayerCount: 2
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: Ygrave
@@ -21947,7 +21954,7 @@ SplineSet
  151 772 l 1
  169.3 789.7 192.8 805.4 227 817 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: ygrave
@@ -21993,7 +22000,7 @@ SplineSet
  -46 677 -23 694 11 694 c 0
  16 694 22 693 26 692 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EF4
@@ -22032,7 +22039,7 @@ SplineSet
  377.4 289.4 377 273 377 245 c 2
  377 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EF5
@@ -22069,7 +22076,7 @@ SplineSet
  475 273 404 119 318 -74 c 0
  305 -104 291 -132 274 -160 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EF6
@@ -22122,7 +22129,7 @@ SplineSet
  221 781 249 815 303 815 c 0
  367 815 382 775 382 759 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EF7
@@ -22173,7 +22180,7 @@ SplineSet
  135 673 168 708 210 708 c 0
  265 708 281 667 281 650 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EF8
@@ -22212,7 +22219,7 @@ SplineSet
  377.4 289.4 377 273 377 245 c 2
  377 122 l 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni1EF9
@@ -22249,7 +22256,7 @@ SplineSet
  475 273 404 119 318 -74 c 0
  305 -104 291 -132 274 -160 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni2000
@@ -23977,7 +23984,7 @@ SplineSet
  646 49 l 1
  609 17 568 -12 509 -12 c 0
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2101
@@ -24031,7 +24038,7 @@ SplineSet
  623 145 663 115 655 79 c 1
  644 19 581 -14 510 -14 c 0
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2102
@@ -24091,7 +24098,7 @@ SplineSet
  341 503 288 458 233 458 c 0
  178 458 142 503 152 558 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni2105
@@ -24130,7 +24137,7 @@ SplineSet
  728 73 619 -13 529 -13 c 0
  436 -13 431 67 438 102 c 0
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2106
@@ -24185,7 +24192,7 @@ SplineSet
  595 283 593 263 591 251 c 0
  589 240 581 219 572 199 c 2
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2109
@@ -24249,7 +24256,7 @@ SplineSet
  341 503 288 458 233 458 c 0
  178 458 142 503 152 558 c 0
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni210D
@@ -24552,7 +24559,7 @@ SplineSet
  744 265 772 223 813 223 c 0
  840 223 876 251 888 314 c 0
 EndSplineSet
-LCarets2: 1 -62 
+LCarets2: 1 -62
 EndChar
 
 StartChar: uni211A
@@ -24820,7 +24827,7 @@ SplineSet
  734 314 738 326 740 337 c 0
  740 339 741 342 741 344 c 2
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni2124
@@ -25023,7 +25030,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" one fraction three
 Ligature2: "'frac' Brueche 1" one slash three
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: twothirds
@@ -25077,7 +25084,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" two fraction three
 Ligature2: "'frac' Brueche 1" two slash three
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2155
@@ -25127,7 +25134,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" one fraction five
 Ligature2: "'frac' Brueche 1" one slash five
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2156
@@ -25180,7 +25187,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" two fraction five
 Ligature2: "'frac' Brueche 1" two slash five
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2157
@@ -25235,7 +25242,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" three fraction five
 Ligature2: "'frac' Brueche 1" three slash five
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2158
@@ -25295,7 +25302,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" four fraction five
 Ligature2: "'frac' Brueche 1" four slash five
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: oneeighth
@@ -25350,7 +25357,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" one fraction eight
 Ligature2: "'frac' Brueche 1" one slash eight
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: threeeighths
@@ -25410,7 +25417,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" three fraction eight
 Ligature2: "'frac' Brueche 1" three slash eight
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: fiveeighths
@@ -25469,7 +25476,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" three fraction eight
 Ligature2: "'frac' Brueche 1" five slash eight
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: seveneighths
@@ -25521,7 +25528,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" seven fraction eight
 Ligature2: "'frac' Brueche 1" seven slash eight
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
 
 StartChar: uni215F
@@ -25553,7 +25560,7 @@ SplineSet
 EndSplineSet
 Ligature2: "'frac' Brueche 1" one fraction
 Ligature2: "'frac' Brueche 1" one slash
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: arrowleft
@@ -25601,21 +25608,21 @@ EndChar
 StartChar: arrowright
 Encoding: 8594 8594 678
 Width: 640
-Flags: MW
+Flags: HMW
 LayerCount: 2
 Fore
 SplineSet
-900 82 m 1
- 862 82 l 1
- 892 154 941 208 973 239 c 1
- 509 239 l 1
- 509 291 l 1
- 973 291 l 1
- 940 318 899 364 860 448 c 1
- 900 448 l 1
- 900 447 1008 319 1116 275 c 1
- 1116 252 l 1
- 1067 235 986 179 900 82 c 1
+407.5 82 m 1
+ 369.5 82 l 1
+ 399.5 154 448.5 208 480.5 239 c 1
+ 16.5 239 l 1
+ 16.5 291 l 1
+ 480.5 291 l 1
+ 447.5 318 406.5 364 367.5 448 c 1
+ 407.5 448 l 1
+ 407.5 447 515.5 319 623.5 275 c 1
+ 623.5 252 l 1
+ 574.5 235 493.5 179 407.5 82 c 1
 EndSplineSet
 EndChar
 
@@ -25751,21 +25758,21 @@ EndChar
 StartChar: uni2198
 Encoding: 8600 8600 684
 Width: 640
-Flags: MW
+Flags: HMW
 LayerCount: 2
 Fore
 SplineSet
--307 38 m 1
- -334 64 l 1
- -262 94 -189 98 -144 97 c 1
- -623 575 l 1
- -586 612 l 1
- -108 134 l 1
- -112 176 -109 238 -77 325 c 1
- -48 296 l 1
- -49 295 -63 128 -18 21 c 1
- -34 5 l 1
- -81 28 -178 46 -307 38 c 1
+333.5 38 m 1
+ 306.5 64 l 1
+ 378.5 94 451.5 98 496.5 97 c 1
+ 17.5 575 l 1
+ 54.5 612 l 1
+ 532.5 134 l 1
+ 528.5 176 531.5 238 563.5 325 c 1
+ 592.5 296 l 1
+ 591.5 295 577.5 128 622.5 21 c 1
+ 606.5 5 l 1
+ 559.5 28 462.5 46 333.5 38 c 1
 EndSplineSet
 EndChar
 
@@ -25776,17 +25783,17 @@ Flags: HMW
 LayerCount: 2
 Fore
 SplineSet
--585.4 292.1 m 1
- -558.6 319 l 1
- -528.9 246.9 -525.3 174 -526 129.5 c 1
- -48 608 l 1
- -11 571 l 1
- -489.3 92.7 l 1
- -446.9 96.9 -385.4 93.4 -298.4 61.6 c 1
- -326.6 33.3 l 2
- -327.3 34 -494.2 48.2 -601.7 2.9 c 1
- -618 19.2 l 1
- -595.4 65.9 -577.6 162.7 -585.4 292.1 c 1
+49.099609375 292.099609375 m 1
+ 75.900390625 319 l 1
+ 105.599609375 246.900390625 109.200195312 174 108.5 129.5 c 1
+ 586.5 608 l 1
+ 623.5 571 l 1
+ 145.200195312 92.7001953125 l 1
+ 187.599609375 96.900390625 249.099609375 93.400390625 336.099609375 61.599609375 c 1
+ 307.900390625 33.2998046875 l 2
+ 307.200195312 34 140.299804688 48.2001953125 32.7998046875 2.900390625 c 1
+ 16.5 19.2001953125 l 1
+ 39.099609375 65.900390625 56.900390625 162.700195312 49.099609375 292.099609375 c 1
 EndSplineSet
 EndChar
 
@@ -25817,7 +25824,7 @@ SplineSet
  15 278 l 1
  64 295 145 351 231 448 c 1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
 
 StartChar: uni219B
@@ -28162,7 +28169,7 @@ SplineSet
  449 94 476 111 501 111 c 0
  598 111 608 32 608 15 c 0
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction six
 Ligature2: "'frac' Brueche 1" one slash six
 EndChar
@@ -28212,7 +28219,7 @@ SplineSet
  136.3 345 147.3 338 169.3 338 c 0
  214.3 338 231.3 373 231.3 414 c 0
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" five fraction six
 Ligature2: "'frac' Brueche 1" five slash six
 EndChar
@@ -28452,7 +28459,7 @@ SplineSet
  201 229 195 227 190 213 c 2
  145 79 l 2
 EndSplineSet
-Comment: "Dies sind alternative Umlaute, die im Deutschen vorzuziehen sind." 
+Comment: "Dies sind alternative Umlaute, die im Deutschen vorzuziehen sind."
 Colour: ffffff
 EndChar
 
@@ -28486,7 +28493,7 @@ SplineSet
  149 585 228 625 318 625 c 0
  481 625 606 507 606 313 c 0
 EndSplineSet
-Comment: "Dies sind alternative Umlaute, die im Deutschen vorzuziehen sind." 
+Comment: "Dies sind alternative Umlaute, die im Deutschen vorzuziehen sind."
 Colour: ffffff
 EndChar
 
@@ -28530,7 +28537,7 @@ SplineSet
  259 609 259 586 253 580 c 1
  179 577 173 572 173 493 c 2
 EndSplineSet
-Comment: "Dies sind alternative Umlaute, die im Deutschen vorzuziehen sind." 
+Comment: "Dies sind alternative Umlaute, die im Deutschen vorzuziehen sind."
 Colour: ffffff
 EndChar
 


### PR DESCRIPTION
Some of the arrows in Libertinus Mono seemed to be off-centre (namely, arrowright, uni2198, and uni2199). With the code
```
\begin{document}
\usepackage{unicode-math}
\setmonofont{Libertinus Mono}
\begin{document}
\texttt{→off.}
\end{document}
```
the output
![spacing](https://user-images.githubusercontent.com/1848620/32695548-ef54ab74-c72c-11e7-9d30-ed60e272fa07.png)
is produced with LuaLaTeX. Now, this output
![spacing-fixed](https://user-images.githubusercontent.com/1848620/32695549-00340264-c72d-11e7-8b6a-b41de6ff2ec4.png)
is produced.





