### PR TITLE
Normalize order of per-glyph feature lines (Substitution2, Ligature2 ... )

### DIFF
--- a/sources/LibertinusMath-Regular.sfd
+++ b/sources/LibertinusMath-Regular.sfd
@@ -49891,8 +49891,8 @@ SplineSet
  368 469 l 2
  368 488.7 369 528 378 564 c 1
 EndSplineSet
-Substitution2: "Substitution f short 1" f_f.short
 LCarets2: 1 266
+Substitution2: "Substitution f short 1" f_f.short
 EndChar
 
 StartChar: f_i
@@ -85595,8 +85595,8 @@ SplineSet
  287 621 189 529 189 320 c 2
  189 122 l 2
 EndSplineSet
-Substitution2: "'ss04' Stilgruppe 4 1" uni1E9E.alt
 Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
+Substitution2: "'ss04' Stilgruppe 4 1" uni1E9E.alt
 EndChar
 
 StartChar: uni2201

--- a/sources/LibertinusMono-Regular.sfd
+++ b/sources/LibertinusMono-Regular.sfd
@@ -7634,9 +7634,9 @@ SplineSet
  521 527 550 435 550 328 c 0
  550 74 409 -10 317 -10 c 0
 EndSplineSet
-Substitution2: "'zero' gestrichene Null 1" uniF638
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
 Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'zero' gestrichene Null 1" uniF638
 EndChar
 
 StartChar: H
@@ -8845,9 +8845,9 @@ SplineSet
  394 456.5 380 439.8 380 372 c 2
  380 134 l 2
 EndSplineSet
-Substitution2: "Substitution dotless forms 1" dotlessi
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uniE150
 Substitution2: "'sups' Hochgestellte 1" uni2071
+Substitution2: "Substitution dotless forms 1" dotlessi
 EndChar
 
 StartChar: j
@@ -8879,8 +8879,8 @@ SplineSet
  444 621 417 590 386 590 c 0
  359 590 332 620 332 650 c 0
 EndSplineSet
-Substitution2: "Substitution dotless forms 1" uniF6BE
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uniE151
+Substitution2: "Substitution dotless forms 1" uniF6BE
 EndChar
 
 StartChar: k
@@ -14827,8 +14827,8 @@ SplineSet
  69 614 98 613 148 613 c 0
  161 613 173 614 182 615 c 0
 EndSplineSet
-Substitution2: "'ss07' Swap Eng styles-1" Eng.UCStyle
 Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap Eng styles-1" Eng.UCStyle
 EndChar
 
 StartChar: eng
@@ -24795,9 +24795,9 @@ SplineSet
  456.1 84.5 456.8 95.9 459.5 105 c 1
  503.5 111 530.5 137 530.5 178 c 0
 EndSplineSet
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction three
 Ligature2: "'frac' Brueche 1" one slash three
-LCarets2: 2 0 0
 EndChar
 
 StartChar: twothirds
@@ -24849,9 +24849,9 @@ SplineSet
  101.8 580.7 107 567.9 105.7 560 c 0
  102.7 542 85 536.7 75 536.7 c 0
 EndSplineSet
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" two fraction three
 Ligature2: "'frac' Brueche 1" two slash three
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2155
@@ -24899,9 +24899,9 @@ SplineSet
  443.7 -52 454.7 -59 476.7 -59 c 0
  521.7 -59 538.7 -24 538.7 17 c 0
 EndSplineSet
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction five
 Ligature2: "'frac' Brueche 1" one slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2156
@@ -24952,9 +24952,9 @@ SplineSet
  454.7 -51 465.7 -58 487.7 -58 c 0
  532.7 -58 549.7 -23 549.7 18 c 0
 EndSplineSet
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" two fraction five
 Ligature2: "'frac' Brueche 1" two slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2157
@@ -25007,9 +25007,9 @@ SplineSet
  117.1 478.5 117.8 489.9 120.5 499 c 1
  164.5 505 191.5 531 191.5 572 c 0
 EndSplineSet
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three fraction five
 Ligature2: "'frac' Brueche 1" three slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2158
@@ -25067,9 +25067,9 @@ SplineSet
  145.1 323 144.1 338 149.1 346 c 1
  189.1 348 202.1 351 202.1 392 c 2
 EndSplineSet
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" four fraction five
 Ligature2: "'frac' Brueche 1" four slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: oneeighth
@@ -25122,9 +25122,9 @@ SplineSet
  554.7 17 553.7 43 513.7 63 c 2
  484.7 77 l 1
 EndSplineSet
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction eight
 Ligature2: "'frac' Brueche 1" one slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: threeeighths
@@ -25182,9 +25182,9 @@ SplineSet
  130.1 477.5 130.8 488.9 133.5 498 c 1
  177.5 504 204.5 530 204.5 571 c 0
 EndSplineSet
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three fraction eight
 Ligature2: "'frac' Brueche 1" three slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: fiveeighths
@@ -25241,9 +25241,9 @@ SplineSet
  153.3 345 164.3 338 186.3 338 c 0
  231.3 338 248.3 373 248.3 414 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" three fraction eight
-Ligature2: "'frac' Brueche 1" five slash eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five slash eight
+Ligature2: "'frac' Brueche 1" three fraction eight
 EndChar
 
 StartChar: seveneighths
@@ -25293,9 +25293,9 @@ SplineSet
  208 428 264 552 290 597 c 1
  190 597 l 2
 EndSplineSet
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" seven fraction eight
 Ligature2: "'frac' Brueche 1" seven slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni215F

--- a/sources/LibertinusSans-Bold.sfd
+++ b/sources/LibertinusSans-Bold.sfd
@@ -483,9 +483,9 @@ SplineSet
  102 -40 44 117.9 44 252 c 0
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenleft.sc
+Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208D
 Substitution2: "'sups' Hochgestellte 1" uni207D
-Substitution2: "'case' Versalformen 1" parenleft.sc
 EndChar
 
 StartChar: parenright
@@ -504,9 +504,9 @@ SplineSet
  236 544 294 386.1 294 252 c 0
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenright.sc
+Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208E
 Substitution2: "'sups' Hochgestellte 1" uni207E
-Substitution2: "'case' Versalformen 1" parenright.sc
 Colour: ff00ff
 EndChar
 
@@ -603,10 +603,10 @@ SplineSet
  346 591 337 550 337 442 c 2
  337 189 l 2
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni00B9
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
-Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'onum' Minuskelziffern 1" one.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" one.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
+Substitution2: "'sups' Hochgestellte 1" uni00B9
 EndChar
 
 StartChar: two
@@ -638,10 +638,10 @@ SplineSet
  299 338 302 390 302 454 c 0
  302 516 262 556 226 556 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni00B2
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
-Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'onum' Minuskelziffern 1" two.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" two.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
+Substitution2: "'sups' Hochgestellte 1" uni00B2
 EndChar
 
 StartChar: three
@@ -674,10 +674,10 @@ SplineSet
  102 130 l 1
  135 71 138 31 213 31 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni00B3
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
-Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'onum' Minuskelziffern 1" three.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" three.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
+Substitution2: "'sups' Hochgestellte 1" uni00B3
 EndChar
 
 StartChar: four
@@ -712,10 +712,10 @@ SplineSet
  251 0 l 1
  258 49 261 98 261 162 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2074
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
-Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'onum' Minuskelziffern 1" four.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" four.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
+Substitution2: "'sups' Hochgestellte 1" uni2074
 EndChar
 
 StartChar: five
@@ -750,10 +750,10 @@ SplineSet
  439 308.5 466 258.9 466 206 c 0
  466 76 362 -10 242 -10 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2075
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
-Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'onum' Minuskelziffern 1" five.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" five.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
+Substitution2: "'sups' Hochgestellte 1" uni2075
 EndChar
 
 StartChar: six
@@ -780,10 +780,10 @@ SplineSet
  228 578.5 303 605.5 444 610 c 1
  451.8 600.4 453.1 581.2 450 569 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2076
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
-Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'onum' Minuskelziffern 1" six.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" six.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
+Substitution2: "'sups' Hochgestellte 1" uni2076
 EndChar
 
 StartChar: seven
@@ -805,10 +805,10 @@ SplineSet
  130 -6 l 1
  194 139 300 310 375 496 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2077
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
-Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'onum' Minuskelziffern 1" seven.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
+Substitution2: "'sups' Hochgestellte 1" uni2077
 EndChar
 
 StartChar: nine
@@ -835,10 +835,10 @@ SplineSet
  294 21.5 219 -5.5 78 -10 c 1
  70.2 -0.4 68.9 18.8 72 31 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2079
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
-Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'onum' Minuskelziffern 1" nine.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
+Substitution2: "'sups' Hochgestellte 1" uni2079
 Colour: ff00ff
 EndChar
 
@@ -1009,9 +1009,9 @@ SplineSet
  399.8 220.4 365.1 221 333 221 c 0
  297.3 221 238.3 220.1 200.3 219.2 c 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" A.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" a.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" A.elb
 EndChar
 
 StartChar: B
@@ -1052,9 +1052,9 @@ SplineSet
  93 648 l 1
  93 648 143 645 177 645 c 0
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" B.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" b.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" B.elb
 EndChar
 
 StartChar: C
@@ -1084,9 +1084,9 @@ SplineSet
  52 419.9 97.1 522.3 176 584 c 0
  238.5 632.8 323 658 414 658 c 0
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" C.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" c.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" C.elb
 EndChar
 
 StartChar: D
@@ -1119,9 +1119,9 @@ SplineSet
  91 648 l 1
  91 648 141 645 175 645 c 0
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" D.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" d.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" D.elb
 EndChar
 
 StartChar: E
@@ -1168,9 +1168,9 @@ SplineSet
  408 308 288 311 240 311 c 1
  240 200 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" E.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" e.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" E.elb
 EndChar
 
 StartChar: F
@@ -1212,9 +1212,9 @@ SplineSet
  88 648 138 645 172 645 c 2
  468 645 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" F.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" f.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" F.elb
 EndChar
 
 StartChar: G
@@ -1252,9 +1252,9 @@ SplineSet
  467 45 505 51 539 83 c 1
  539 117 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" G.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" g.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" G.elb
 EndChar
 
 StartChar: grave
@@ -1955,8 +1955,8 @@ LayerCount: 2
 Fore
 Refer: 666 775 N 1 0 0 1 339 199 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 Colour: ff00ff
 EndChar
 
@@ -5351,9 +5351,9 @@ SplineSet
  490 486 428 421 342 372 c 1
  358 344 389.9 293.8 451 209 c 1
 EndSplineSet
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ampersand.alt
 Substitution2: "'salt' Stilistische Alternativformen 1" ampersand.alt
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" ampersand.alt
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ampersand.alt
 EndChar
 
 StartChar: quotesingle
@@ -5407,8 +5407,8 @@ SplineSet
  306 260 292 221 279 221 c 2
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" hyphen.sc
-Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 Substitution2: "'case' Versalformen 1" hyphen.cap
+Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 EndChar
 
 StartChar: period
@@ -5444,11 +5444,11 @@ SplineSet
  360.7 610 484 542.7 484 307 c 0
  484 69 354 -10 255 -10 c 0
 EndSplineSet
-Substitution2: "'zero' gestrichene Null 1" zero.slash
-Substitution2: "'sups' Hochgestellte 1" uni2070
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
-Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
+Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'zero' gestrichene Null 1" zero.slash
 EndChar
 
 StartChar: I
@@ -5478,9 +5478,9 @@ SplineSet
  89 54 93 125 93 200 c 2
  93 445 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" I.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" i.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" I.elb
 EndChar
 
 StartChar: J
@@ -5511,9 +5511,9 @@ SplineSet
  125 -119 142 -66.1 142 -24 c 0
  142 45.8 140 114 140 155 c 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" J.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" j.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" J.elb
 EndChar
 
 StartChar: K
@@ -5556,9 +5556,9 @@ SplineSet
  89 54 93 125 93 200 c 2
  93 445 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" K.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" k.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" K.elb
 Colour: ff80cc
 EndChar
 
@@ -5594,9 +5594,9 @@ SplineSet
  249 592 247 520 247 445 c 2
  247 210 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" L.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" l.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" L.elb
 EndChar
 
 StartChar: M
@@ -5630,9 +5630,9 @@ SplineSet
  63 0 40 0 29 -3 c 1
  71.9 188 124.9 439 161 653 c 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" M.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" m.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" M.elb
 EndChar
 
 StartChar: N
@@ -5674,9 +5674,9 @@ SplineSet
  88 53 92.8 122.2 96 200 c 1
  101 445 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" N.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" n.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" N.elb
 EndChar
 
 StartChar: O
@@ -5701,9 +5701,9 @@ SplineSet
  52 506 194 658 397 658 c 0
  610 658 747 527 747 329 c 0
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" O.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" o.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" O.elb
 EndChar
 
 StartChar: P
@@ -5741,9 +5741,9 @@ SplineSet
  89 54 93 125 93 200 c 2
  93 445 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" P.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" p.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" P.elb
 EndChar
 
 StartChar: Q
@@ -5771,9 +5771,9 @@ SplineSet
  610 658 747 527 747 329 c 0
  747 198.6 689.6 94.1 590.3 37.2 c 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" Q.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" q.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" Q.elb
 Colour: ff80cc
 EndChar
 
@@ -5818,9 +5818,9 @@ SplineSet
  356.7 214.8 330.1 262.1 301.6 296.8 c 1
  281.9 296.1 262.8 296 245 296 c 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" R.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" r.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" R.elb
 EndChar
 
 StartChar: S
@@ -5855,9 +5855,9 @@ SplineSet
  73 161 l 1
  108 108 192 42 253 42 c 0
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" S.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" s.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" S.elb
 EndChar
 
 StartChar: T
@@ -5894,9 +5894,9 @@ SplineSet
  227 54 229 125 229 200 c 2
  229 436 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" T.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" t.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" T.elb
 EndChar
 
 StartChar: U
@@ -5932,9 +5932,9 @@ SplineSet
  524.2 55 547 165 547 277 c 2
  547 445 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" U.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" u.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" U.elb
 EndChar
 
 StartChar: V
@@ -5959,9 +5959,9 @@ SplineSet
  134 645 176 645 193 648 c 1
  202.4 615.2 247.7 454.2 364.1 178.8 c 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" V.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" v.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" V.elb
 EndChar
 
 StartChar: W
@@ -5994,9 +5994,9 @@ SplineSet
  495 645 557 645 574 648 c 1
  583.5 614.8 619.9 454.1 735.2 178.6 c 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" W.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" w.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" W.elb
 EndChar
 
 StartChar: X
@@ -6030,9 +6030,9 @@ SplineSet
  585.8 590 500.5 489.9 404.3 365 c 1
  466.8 275 559.2 144.7 661 -3 c 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" X.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" x.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" X.elb
 EndChar
 
 StartChar: Y
@@ -6060,9 +6060,9 @@ SplineSet
  591 645 613 645 626 648 c 1
  514.5 477.5 448 380.9 406.2 304.2 c 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" Y.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" y.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" Y.elb
 EndChar
 
 StartChar: Z
@@ -6100,9 +6100,9 @@ SplineSet
  618 634 608 619 588 591 c 0
  211.1 69.4 208 66.8 208 63 c 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" Z.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" z.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" Z.elb
 EndChar
 
 StartChar: bracketleft
@@ -6228,9 +6228,9 @@ SplineSet
  428.6 374.3 441 337.1 441 277 c 0
  441 266 437 109 437 80 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" a.superior
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2090
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" a.sc
+Substitution2: "'sups' Hochgestellte 1" a.superior
 EndChar
 
 StartChar: b
@@ -6271,8 +6271,8 @@ SplineSet
  222.3 626.7 218 574 218 500 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" b.inferior
-Substitution2: "'sups' Hochgestellte 1" b.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" b.sc
+Substitution2: "'sups' Hochgestellte 1" b.superior
 EndChar
 
 StartChar: c
@@ -6306,8 +6306,8 @@ SplineSet
  365 360 335.5 389 297 389 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" c.inferior
-Substitution2: "'sups' Hochgestellte 1" c.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" c.sc
+Substitution2: "'sups' Hochgestellte 1" c.superior
 EndChar
 
 StartChar: d
@@ -6348,10 +6348,10 @@ SplineSet
  375 54 l 1
  373 54 l 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" d.elb
 Substitution2: "'sinf' Wissenschaftliche Indices 1" d.inferior
-Substitution2: "'sups' Hochgestellte 1" d.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" d.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" d.elb
+Substitution2: "'sups' Hochgestellte 1" d.superior
 EndChar
 
 StartChar: e
@@ -6385,9 +6385,9 @@ SplineSet
  226 79.1 262.4 66 311 66 c 0
  353 66 401.5 69.5 448 107 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" e.superior
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2091
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" e.sc
+Substitution2: "'sups' Hochgestellte 1" e.superior
 EndChar
 
 StartChar: f
@@ -6431,8 +6431,8 @@ SplineSet
  222 379 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" f.inferior
-Substitution2: "'sups' Hochgestellte 1" f.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" f.sc
+Substitution2: "'sups' Hochgestellte 1" f.superior
 EndChar
 
 StartChar: g
@@ -6485,10 +6485,10 @@ SplineSet
  262.2 -17 235.5 -18 206 -18 c 0
  197 -18 189.4 -16.8 183 -16 c 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" g.elb
 Substitution2: "'sinf' Wissenschaftliche Indices 1" g.inferior
-Substitution2: "'sups' Hochgestellte 1" g.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" g.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" g.elb
+Substitution2: "'sups' Hochgestellte 1" g.superior
 EndChar
 
 StartChar: h
@@ -6532,10 +6532,10 @@ SplineSet
  82.5 53.5 86 105 86 180 c 2
  86 474 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" h.elb
 Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B0
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" h.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" h.elb
+Substitution2: "'sups' Hochgestellte 1" uni02B0
 EndChar
 
 StartChar: i
@@ -6549,10 +6549,10 @@ LayerCount: 2
 Fore
 Refer: 666 775 N 1 0 0 1 317 14 2
 Refer: 419 305 N 1 0 0 1 0 0 2
-Substitution2: "'ss05' Elbischer Stilsatz-1" i.elb
+Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > i.sc 1" i.sc
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
-Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
+Substitution2: "'ss05' Elbischer Stilsatz-1" i.elb
 Substitution2: "'sups' Hochgestellte 1" uni2071
 Colour: ff00ff
 EndChar
@@ -6565,10 +6565,10 @@ LayerCount: 2
 Fore
 Refer: 666 775 N 1 0 0 1 354 14 2
 Refer: 1652 567 N 1 0 0 1 0 0 2
-Substitution2: "'ss05' Elbischer Stilsatz-1" j.elb
 Substitution2: "'sinf' Wissenschaftliche Indices 1" j.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" j.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" j.elb
+Substitution2: "'sups' Hochgestellte 1" uni02B2
 Colour: ff00ff
 EndChar
 
@@ -6611,8 +6611,8 @@ SplineSet
  82.5 53.5 86 125 86 200 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" k.inferior
-Substitution2: "'sups' Hochgestellte 1" k.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" k.sc
+Substitution2: "'sups' Hochgestellte 1" k.superior
 Colour: ff80cc
 EndChar
 
@@ -6693,10 +6693,10 @@ SplineSet
  210.5 416.5 211.8 374.8 211.8 352 c 1
  216 349 l 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" m.elb
 Substitution2: "'sinf' Wissenschaftliche Indices 1" m.inferior
-Substitution2: "'sups' Hochgestellte 1" m.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" m.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" m.elb
+Substitution2: "'sups' Hochgestellte 1" m.superior
 EndChar
 
 StartChar: n
@@ -6738,10 +6738,10 @@ SplineSet
  463 439 512 396 512 291 c 2
  512 180 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" n.elb
 Substitution2: "'sinf' Wissenschaftliche Indices 1" n.inferior
-Substitution2: "'sups' Hochgestellte 1" uni207F
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" n.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" n.elb
+Substitution2: "'sups' Hochgestellte 1" uni207F
 EndChar
 
 StartChar: o
@@ -6767,9 +6767,9 @@ SplineSet
  342 40 383 72 383 187 c 0
  383 326 363 389 278 389 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" o.superior
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2092
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" o.sc
+Substitution2: "'sups' Hochgestellte 1" o.superior
 EndChar
 
 StartChar: p
@@ -6808,10 +6808,10 @@ SplineSet
  210.5 416.5 211.8 383.8 211.8 361 c 1
  216 358 l 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" p.elb
 Substitution2: "'sinf' Wissenschaftliche Indices 1" p.inferior
-Substitution2: "'sups' Hochgestellte 1" p.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" p.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" p.elb
+Substitution2: "'sups' Hochgestellte 1" p.superior
 EndChar
 
 StartChar: q
@@ -6848,8 +6848,8 @@ SplineSet
  313.9 439 362.3 435.8 404 433 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" q.inferior
-Substitution2: "'sups' Hochgestellte 1" q.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" q.sc
+Substitution2: "'sups' Hochgestellte 1" q.superior
 EndChar
 
 StartChar: r
@@ -6886,10 +6886,10 @@ SplineSet
  219.5 416.5 220.8 374.8 220.8 352 c 1
  225 349 l 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" r.elb
 Substitution2: "'sinf' Wissenschaftliche Indices 1" r.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" r.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" r.elb
+Substitution2: "'sups' Hochgestellte 1" uni02B3
 EndChar
 
 StartChar: uni02E2
@@ -6963,8 +6963,8 @@ SplineSet
  48.4 430.4 69.5 429.1 90 429 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" t.inferior
-Substitution2: "'sups' Hochgestellte 1" t.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" t.sc
+Substitution2: "'sups' Hochgestellte 1" t.superior
 EndChar
 
 StartChar: u
@@ -7008,10 +7008,10 @@ SplineSet
  374 64 l 1
  372 64 l 1
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" u.elb
 Substitution2: "'sinf' Wissenschaftliche Indices 1" u.inferior
-Substitution2: "'sups' Hochgestellte 1" u.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" u.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" u.elb
+Substitution2: "'sups' Hochgestellte 1" u.superior
 EndChar
 
 StartChar: v
@@ -7038,8 +7038,8 @@ SplineSet
  259 0 225 -1 214 -3 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" v.inferior
-Substitution2: "'sups' Hochgestellte 1" v.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" v.sc
+Substitution2: "'sups' Hochgestellte 1" v.superior
 EndChar
 
 StartChar: w
@@ -7076,8 +7076,8 @@ SplineSet
  245 -1 210 -1 201 -4 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" w.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B7
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" w.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B7
 EndChar
 
 StartChar: uni02E3
@@ -7133,8 +7133,8 @@ SplineSet
  177.1 109.2 64.5 341.1 20 432 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" y.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B8
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" y.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B8
 EndChar
 
 StartChar: z
@@ -7173,8 +7173,8 @@ SplineSet
  271 370 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" z.inferior
-Substitution2: "'sups' Hochgestellte 1" z.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" z.sc
+Substitution2: "'sups' Hochgestellte 1" z.superior
 EndChar
 
 StartChar: braceleft
@@ -7969,8 +7969,8 @@ SplineSet
 EndSplineSet
 Refer: 1057 8308 N 1 0 0 1 348 -499 2
 Refer: 336 185 N 1 0 0 1 -3 -49 2
-Ligature2: "'frac' Brueche 1" one slash four
 LCarets2: 2 215 424
+Ligature2: "'frac' Brueche 1" one slash four
 Colour: ff80cc
 EndChar
 
@@ -9942,10 +9942,10 @@ SplineSet
  89 54 93 125 93 200 c 2
  93 445 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap Eng forms-1" Eng.UCStyle
-Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eng.sc
+Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap Eng forms-1" Eng.UCStyle
 Comment: "Sieht in Times anders aus"
 EndChar
 
@@ -12378,8 +12378,8 @@ LayerCount: 2
 Fore
 Refer: 2262 -1 N 1 0 0 1 775 0 2
 Refer: 349 198 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Colour: ff00ff
 EndChar
 
@@ -22405,9 +22405,9 @@ SplineSet
 EndSplineSet
 Refer: 336 185 N 1 0 0 1 -14 -49 2
 Refer: 330 179 N 1 0 0 1 358 -496 2
-Ligature2: "'frac' Brueche 1" one slash three
-Ligature2: "'frac' Brueche 1" one fraction three
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction three
+Ligature2: "'frac' Brueche 1" one slash three
 Colour: ff80cc
 EndChar
 
@@ -22426,9 +22426,9 @@ SplineSet
 EndSplineSet
 Refer: 330 179 N 1 0 0 1 352 -498 2
 Refer: 329 178 N 1 0 0 1 0 -101 2
-Ligature2: "'frac' Brueche 1" two slash three
-Ligature2: "'frac' Brueche 1" two fraction three
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" two fraction three
+Ligature2: "'frac' Brueche 1" two slash three
 Colour: ff80cc
 EndChar
 
@@ -22447,9 +22447,9 @@ SplineSet
 EndSplineSet
 Refer: 1058 8309 N 1 0 0 1 342 -497 2
 Refer: 336 185 N 1 0 0 1 -7 -48 2
-Ligature2: "'frac' Brueche 1" one slash five
-Ligature2: "'frac' Brueche 1" one fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction five
+Ligature2: "'frac' Brueche 1" one slash five
 Colour: ff80cc
 EndChar
 
@@ -22468,9 +22468,9 @@ SplineSet
 EndSplineSet
 Refer: 1058 8309 N 1 0 0 1 343 -496 2
 Refer: 329 178 N 1 0 0 1 1 -48 2
-Ligature2: "'frac' Brueche 1" two slash five
-Ligature2: "'frac' Brueche 1" two fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" two fraction five
+Ligature2: "'frac' Brueche 1" two slash five
 Colour: ff80cc
 EndChar
 
@@ -22489,9 +22489,9 @@ SplineSet
 EndSplineSet
 Refer: 1058 8309 N 1 0 0 1 340 -496 2
 Refer: 330 179 N 1 0 0 1 -1 -102 2
-Ligature2: "'frac' Brueche 1" three slash five
-Ligature2: "'frac' Brueche 1" three fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three fraction five
+Ligature2: "'frac' Brueche 1" three slash five
 Colour: ff80cc
 EndChar
 
@@ -22510,9 +22510,9 @@ SplineSet
 EndSplineSet
 Refer: 1058 8309 N 1 0 0 1 344 -496 2
 Refer: 1057 8308 N 1 0 0 1 -9 -48 2
-Ligature2: "'frac' Brueche 1" four slash five
-Ligature2: "'frac' Brueche 1" four fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" four fraction five
+Ligature2: "'frac' Brueche 1" four slash five
 Colour: ff80cc
 EndChar
 
@@ -22531,9 +22531,9 @@ SplineSet
 EndSplineSet
 Refer: 1061 8312 N 1 0 0 1 348 -499 2
 Refer: 336 185 N 1 0 0 1 -7 -49 2
-Ligature2: "'frac' Brueche 1" one slash eight
-Ligature2: "'frac' Brueche 1" one fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction eight
+Ligature2: "'frac' Brueche 1" one slash eight
 Colour: ff80cc
 EndChar
 
@@ -22552,9 +22552,9 @@ SplineSet
 EndSplineSet
 Refer: 1061 8312 N 1 0 0 1 347 -497 2
 Refer: 330 179 N 1 0 0 1 2 -103 2
-Ligature2: "'frac' Brueche 1" three slash eight
-Ligature2: "'frac' Brueche 1" three fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three fraction eight
+Ligature2: "'frac' Brueche 1" three slash eight
 Colour: ff80cc
 EndChar
 
@@ -22573,9 +22573,9 @@ SplineSet
 EndSplineSet
 Refer: 1061 8312 N 1 0 0 1 342 -498 2
 Refer: 1058 8309 N 1 0 0 1 -4 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" five slash eight
 Ligature2: "'frac' Brueche 1" three fraction eight
-LCarets2: 2 0 0
 Colour: ff80cc
 EndChar
 
@@ -22594,9 +22594,9 @@ SplineSet
 EndSplineSet
 Refer: 1061 8312 N 1 0 0 1 352 -497 2
 Refer: 1060 8311 N 1 0 0 1 1 -48 2
-Ligature2: "'frac' Brueche 1" seven slash eight
-Ligature2: "'frac' Brueche 1" seven fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" seven fraction eight
+Ligature2: "'frac' Brueche 1" seven slash eight
 Colour: ff80cc
 EndChar
 
@@ -22614,8 +22614,8 @@ SplineSet
  532 601 l 1
 EndSplineSet
 Refer: 336 185 N 1 0 0 1 -10 -48 2
-Ligature2: "'frac' Brueche 1" one slash
 Ligature2: "'frac' Brueche 1" one fraction
+Ligature2: "'frac' Brueche 1" one slash
 Colour: ff80cc
 EndChar
 
@@ -25357,8 +25357,8 @@ SplineSet
  93 459 l 2
  93 537 118 566 162 612 c 0
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" f f
 LCarets2: 1 322
+Ligature2: "'liga' Standardligaturen 1" f f
 EndChar
 
 StartChar: f_i
@@ -27573,8 +27573,8 @@ SplineSet
  472 698 593 633 599 524 c 2
  604 429 l 1
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" s t
 LCarets2: 1 357
+Ligature2: "'hlig' Historische Ligaturen 1" s t
 Colour: ff80cc
 EndChar
 
@@ -29181,8 +29181,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 10 49 N 1 0 0 1 -32 0 2
-Substitution2: "'tnum' Tabellenziffern 1" one
 Substitution2: "'onum' Minuskelziffern 1" one.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" one
 Colour: ff00ff
 EndChar
 
@@ -29193,8 +29193,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 11 50 N 1 0 0 1 -3 0 2
-Substitution2: "'tnum' Tabellenziffern 1" two
 Substitution2: "'onum' Minuskelziffern 1" two.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" two
 Colour: ff00ff
 EndChar
 
@@ -29205,8 +29205,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 12 51 N 1 0 0 1 4 0 2
-Substitution2: "'tnum' Tabellenziffern 1" three
 Substitution2: "'onum' Minuskelziffern 1" three.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" three
 Colour: ff00ff
 EndChar
 
@@ -29217,8 +29217,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 13 52 N 1 0 0 1 11 0 2
-Substitution2: "'tnum' Tabellenziffern 1" four
 Substitution2: "'onum' Minuskelziffern 1" four.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" four
 Colour: ff00ff
 EndChar
 
@@ -29229,8 +29229,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 14 53 N 1 0 0 1 -2 0 2
-Substitution2: "'tnum' Tabellenziffern 1" five
 Substitution2: "'onum' Minuskelziffern 1" five.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" five
 Colour: ff00ff
 EndChar
 
@@ -29241,8 +29241,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 15 54 N 1 0 0 1 -2 0 2
-Substitution2: "'tnum' Tabellenziffern 1" six
 Substitution2: "'onum' Minuskelziffern 1" six.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" six
 Colour: ff00ff
 EndChar
 
@@ -29253,8 +29253,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 2112 56 N 1 0 0 1 -7 0 2
-Substitution2: "'tnum' Tabellenziffern 1" eight
 Substitution2: "'onum' Minuskelziffern 1" eight.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" eight
 EndChar
 
 StartChar: two.oldstyle
@@ -31036,9 +31036,9 @@ SplineSet
 EndSplineSet
 Refer: 1059 8310 N 1 0 0 1 346 -498 2
 Refer: 336 185 N 1 0 0 1 -2 -48 2
-Ligature2: "'frac' Brueche 1" one slash six
-Ligature2: "'frac' Brueche 1" one fraction six
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction six
+Ligature2: "'frac' Brueche 1" one slash six
 Colour: ff80cc
 EndChar
 
@@ -31057,9 +31057,9 @@ SplineSet
 EndSplineSet
 Refer: 1059 8310 N 1 0 0 1 345 -497 2
 Refer: 1058 8309 N 1 0 0 1 -1 -48 2
-Ligature2: "'frac' Brueche 1" five slash six
-Ligature2: "'frac' Brueche 1" five fraction six
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five fraction six
+Ligature2: "'frac' Brueche 1" five slash six
 Colour: ff80cc
 EndChar
 
@@ -38762,8 +38762,8 @@ SplineSet
  93 459 l 2
  93 520 123 583 167 629 c 0
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" f t
 LCarets2: 1 298
+Ligature2: "'liga' Standardligaturen 1" f t
 EndChar
 
 StartChar: uni0360
@@ -38866,8 +38866,8 @@ SplineSet
  436 626 l 1
  404.4 560.7 l 1
 EndSplineSet
-Substitution2: "'tnum' Tabellenziffern 1" zero.slash
 Substitution2: "'onum' Minuskelziffern 1" zero.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" zero.slash
 Colour: ff00ff
 EndChar
 
@@ -38895,8 +38895,8 @@ SplineSet
  747 193.9 685.5 86.7 579.6 31.3 c 1
 EndSplineSet
 Refer: 301 117 N 1 0 0 1 790 0 2
-Ligature2: "'liga' Standardligaturen 1" Q u
 LCarets2: 1 708
+Ligature2: "'liga' Standardligaturen 1" Q u
 Colour: ff80cc
 EndChar
 
@@ -38907,9 +38907,9 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 257 48 N 1 0 0 1 9 0 2
-Substitution2: "'zero' gestrichene Null 1" zero.slashfitted
-Substitution2: "'tnum' Tabellenziffern 1" zero
 Substitution2: "'onum' Minuskelziffern 1" zero.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" zero
+Substitution2: "'zero' gestrichene Null 1" zero.slashfitted
 Colour: ff00ff
 EndChar
 
@@ -38931,8 +38931,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 16 55 N 1 0 0 1 -44 0 2
-Substitution2: "'tnum' Tabellenziffern 1" seven
 Substitution2: "'onum' Minuskelziffern 1" seven.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" seven
 Colour: ff00ff
 EndChar
 
@@ -38943,8 +38943,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 17 57 N 1 0 0 1 5 0 2
-Substitution2: "'tnum' Tabellenziffern 1" nine
 Substitution2: "'onum' Minuskelziffern 1" nine.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" nine
 Colour: ff00ff
 EndChar
 
@@ -44333,10 +44333,10 @@ SplineSet
  74 0 l 1
  82.5 53.5 86 125 86 200 c 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" l.elb
 Substitution2: "'sinf' Wissenschaftliche Indices 1" l.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E1
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" l.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" l.elb
+Substitution2: "'sups' Hochgestellte 1" uni02E1
 EndChar
 
 StartChar: s
@@ -44371,8 +44371,8 @@ SplineSet
  54 113 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" s.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" s.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E2
 EndChar
 
 StartChar: x
@@ -44407,9 +44407,9 @@ SplineSet
  187.4 203 l 1
  190.5 206.8 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni02E3
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2093
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" x.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E3
 EndChar
 
 StartChar: uni03D8
@@ -47701,8 +47701,8 @@ SplineSet
  315 411 268 381 223 305 c 1
  223 290 223 275 223 260 c 2
 EndSplineSet
-Substitution2: "'ss07' Swap Eng forms-1" Eng.UCStyle.sc
 Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle.sc
+Substitution2: "'ss07' Swap Eng forms-1" Eng.UCStyle.sc
 EndChar
 
 StartChar: ohungarumlaut.sc
@@ -48058,10 +48058,10 @@ SplineSet
  172 247 166 194 166 146 c 0
  166 73 212 30 254 30 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2078
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
-Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'onum' Minuskelziffern 1" eight.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
+Substitution2: "'sups' Hochgestellte 1" uni2078
 EndChar
 
 StartChar: uniFFFD
@@ -48159,8 +48159,8 @@ SplineSet
  352 99 l 1
  376 62 412.5 39 468 39 c 0
 EndSplineSet
-Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 EndChar
 
 StartChar: uni2201
@@ -48673,9 +48673,9 @@ SplineSet
  527 363 l 1
  527 445 l 2
 EndSplineSet
-Substitution2: "'ss05' Elbischer Stilsatz-1" H.elb
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" h.sc
+Substitution2: "'ss05' Elbischer Stilsatz-1" H.elb
 Colour: ff80cc
 EndChar
 
@@ -48710,9 +48710,9 @@ SplineSet
  436 626 l 1
  401.7 555 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2070
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
 Substitution2: "'pnum' Proportionalziffern 1" zero.slashfitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
+Substitution2: "'sups' Hochgestellte 1" uni2070
 EndChar
 
 StartChar: germandbls.sc
@@ -48837,9 +48837,9 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 2112 56 N 1 0 0 1 0 0 2
-Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2078
 Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
+Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 EndChar
 
 StartChar: nine.oldstyle
@@ -48930,8 +48930,8 @@ SplineSet
  87 379 l 1
  24 379 l 2
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" t t
 LCarets2: 1 306
+Ligature2: "'liga' Standardligaturen 1" t t
 EndChar
 
 StartChar: c_t
@@ -48984,8 +48984,8 @@ SplineSet
  340 660 285 619 285 563 c 0
  285 511.7 313.7 461.5 376.7 425.6 c 1
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" c t
 LCarets2: 1 407
+Ligature2: "'hlig' Historische Ligaturen 1" c t
 EndChar
 
 StartChar: uni27E6

--- a/sources/LibertinusSans-Italic.sfd
+++ b/sources/LibertinusSans-Italic.sfd
@@ -499,9 +499,9 @@ SplineSet
  42.9 -24 88 207 97.6 252 c 0
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenleft.sc
+Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208D
 Substitution2: "'sups' Hochgestellte 1" uni207D
-Substitution2: "'case' Versalformen 1" parenleft.sc
 EndChar
 
 StartChar: parenright
@@ -520,9 +520,9 @@ SplineSet
  364.2 528 319.2 297 309.6 252 c 0
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenright.sc
+Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208E
 Substitution2: "'sups' Hochgestellte 1" uni207E
-Substitution2: "'case' Versalformen 1" parenright.sc
 Colour: ff00ff
 EndChar
 
@@ -619,10 +619,10 @@ SplineSet
  391 591 378 551 357 443 c 2
  308 189 l 2
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni00B9
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
-Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'onum' Minuskelziffern 1" one.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" one.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
+Substitution2: "'sups' Hochgestellte 1" uni00B9
 EndChar
 
 StartChar: two
@@ -655,10 +655,10 @@ SplineSet
  368.2 353.6 381.8 408 381.8 464.5 c 0
  381.8 516 340.7 548 307.8 548 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni00B2
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
-Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'onum' Minuskelziffern 1" two.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" two.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
+Substitution2: "'sups' Hochgestellte 1" uni00B2
 EndChar
 
 StartChar: three
@@ -697,10 +697,10 @@ SplineSet
  113 117 l 1
  128 59 134 29 208 29 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni00B3
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
-Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'onum' Minuskelziffern 1" three.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" three.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
+Substitution2: "'sups' Hochgestellte 1" uni00B3
 EndChar
 
 StartChar: four
@@ -736,10 +736,10 @@ SplineSet
  313 198 l 1
  374 512 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2074
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
-Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'onum' Minuskelziffern 1" four.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" four.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
+Substitution2: "'sups' Hochgestellte 1" uni2074
 EndChar
 
 StartChar: five
@@ -773,10 +773,10 @@ SplineSet
  431.2 224.6 429.8 210.4 427 196 c 0
  404 78 305 -10 191 -10 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2075
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
-Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'onum' Minuskelziffern 1" five.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" five.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
+Substitution2: "'sups' Hochgestellte 1" uni2075
 EndChar
 
 StartChar: six
@@ -807,10 +807,10 @@ SplineSet
  324 577 399 605 499 611 c 1
  496 583 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2076
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
-Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'onum' Minuskelziffern 1" six.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" six.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
+Substitution2: "'sups' Hochgestellte 1" uni2076
 EndChar
 
 StartChar: seven
@@ -832,10 +832,10 @@ SplineSet
  116 -7 l 1
  209 143 320 332 432 525 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2077
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
-Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'onum' Minuskelziffern 1" seven.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
+Substitution2: "'sups' Hochgestellte 1" uni2077
 EndChar
 
 StartChar: nine
@@ -866,10 +866,10 @@ SplineSet
  253 23 178 -5 78 -11 c 1
  81 17 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2079
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
-Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'onum' Minuskelziffern 1" nine.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
+Substitution2: "'sups' Hochgestellte 1" uni2079
 Colour: ff00ff
 EndChar
 
@@ -2182,8 +2182,8 @@ SplineSet
  115.5 54 132.6 125 148.5 200 c 2
  200.6 445 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 Colour: ff00ff
 EndChar
 
@@ -6792,9 +6792,9 @@ SplineSet
  391.2 363 l 1
  402.6 332 440 254 472.8 192 c 1
 EndSplineSet
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ampersand.alt
 Substitution2: "'salt' Stilistische Alternativformen 1" ampersand.alt
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" ampersand.alt
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ampersand.alt
 EndChar
 
 StartChar: quotesingle
@@ -6847,8 +6847,8 @@ SplineSet
  358 257 337 223 323 223 c 2
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" hyphen.sc
-Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 Substitution2: "'case' Versalformen 1" hyphen.cap
+Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 EndChar
 
 StartChar: period
@@ -6891,11 +6891,11 @@ SplineSet
  473.8 383.5 470.7 348.8 463 309 c 0
  418 75 290 -10 216 -10 c 0
 EndSplineSet
-Substitution2: "'zero' gestrichene Null 1" zero.slash
-Substitution2: "'sups' Hochgestellte 1" uni2070
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
-Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
+Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'zero' gestrichene Null 1" zero.slash
 EndChar
 
 StartChar: I
@@ -7003,8 +7003,8 @@ SplineSet
  200.6 445 l 2
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
-Substitution2: "'ss02' Stilgruppe 2 1" K.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" k.sc
+Substitution2: "'ss02' Stilgruppe 2 1" K.alt
 Colour: ff80cc
 EndChar
 
@@ -7265,8 +7265,8 @@ SplineSet
  252.7 300.5 l 1
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
-Substitution2: "'ss02' Stilgruppe 2 1" R.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" r.sc
+Substitution2: "'ss02' Stilgruppe 2 1" R.alt
 EndChar
 
 StartChar: S
@@ -7663,9 +7663,9 @@ SplineSet
  421 430.3 462.7 436 479 436 c 1
  408 138 l 2
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" a.superior
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2090
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" a.sc
+Substitution2: "'sups' Hochgestellte 1" a.superior
 EndChar
 
 StartChar: b
@@ -7702,8 +7702,8 @@ SplineSet
  292.5 626.7 279 574 263.3 500 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" b.inferior
-Substitution2: "'sups' Hochgestellte 1" b.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" b.sc
+Substitution2: "'sups' Hochgestellte 1" b.superior
 EndChar
 
 StartChar: c
@@ -7736,8 +7736,8 @@ SplineSet
  375 371 349 399 314 399 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" c.inferior
-Substitution2: "'sups' Hochgestellte 1" c.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" c.sc
+Substitution2: "'sups' Hochgestellte 1" c.superior
 EndChar
 
 StartChar: d
@@ -7781,8 +7781,8 @@ SplineSet
  354.6 64 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" d.inferior
-Substitution2: "'sups' Hochgestellte 1" d.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" d.sc
+Substitution2: "'sups' Hochgestellte 1" d.superior
 EndChar
 
 StartChar: e
@@ -7811,9 +7811,9 @@ SplineSet
  416.5 439 444 405.4 444 362.4 c 0
  444 324 426 218 168.3 207.5 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" e.superior
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2091
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" e.sc
+Substitution2: "'sups' Hochgestellte 1" e.superior
 EndChar
 
 StartChar: f
@@ -7859,10 +7859,10 @@ SplineSet
  34 -174 59.1 -128 80.3 -68 c 0
  99 -15 122 120.6 146.8 236 c 2
 EndSplineSet
-Substitution2: "Substitution f short 1" f.short
 Substitution2: "'sinf' Wissenschaftliche Indices 1" f.inferior
-Substitution2: "'sups' Hochgestellte 1" f.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" f.sc
+Substitution2: "'sups' Hochgestellte 1" f.superior
+Substitution2: "Substitution f short 1" f.short
 EndChar
 
 StartChar: g
@@ -7918,8 +7918,8 @@ SplineSet
  327 177 375 218 375 298 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" g.inferior
-Substitution2: "'sups' Hochgestellte 1" g.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" g.sc
+Substitution2: "'sups' Hochgestellte 1" g.superior
 EndChar
 
 StartChar: h
@@ -7961,10 +7961,10 @@ SplineSet
  342 0 l 1
  361.9 53.5 374.5 105.5 390.3 180 c 2
 EndSplineSet
-Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
 Substitution2: "'salt' Stilistische Alternativformen 1" h.alt
-Substitution2: "'sups' Hochgestellte 1" uni02B0
+Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" h.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B0
 EndChar
 
 StartChar: i
@@ -7978,9 +7978,9 @@ LayerCount: 2
 Fore
 Refer: 664 729 N 1 0 0 1 -18 0 2
 Refer: 419 305 N 1 0 0 1 0 0 2
+Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > i.sc 1" i.sc
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
-Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
 Substitution2: "'sups' Hochgestellte 1" uni2071
 Colour: ff00ff
 EndChar
@@ -7994,8 +7994,8 @@ Fore
 Refer: 664 729 N 1 0 0 1 -5 0 2
 Refer: 1719 567 N 1 0 0 1 0 0 2
 Substitution2: "'sinf' Wissenschaftliche Indices 1" j.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" j.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B2
 Colour: ff00ff
 EndChar
 
@@ -8038,8 +8038,8 @@ SplineSet
  208.1 240.3 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" k.inferior
-Substitution2: "'sups' Hochgestellte 1" k.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" k.sc
+Substitution2: "'sups' Hochgestellte 1" k.superior
 Colour: ff80cc
 EndChar
 
@@ -8130,8 +8130,8 @@ SplineSet
  485.7 360.2 486 360.4 486.2 360.6 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" m.inferior
-Substitution2: "'sups' Hochgestellte 1" m.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" m.sc
+Substitution2: "'sups' Hochgestellte 1" m.superior
 EndChar
 
 StartChar: n
@@ -8175,8 +8175,8 @@ SplineSet
  488 249 478 212 471 180 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" n.inferior
-Substitution2: "'sups' Hochgestellte 1" uni207F
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" n.sc
+Substitution2: "'sups' Hochgestellte 1" uni207F
 EndChar
 
 StartChar: o
@@ -8206,9 +8206,9 @@ SplineSet
  389.1 121.4 416.6 176 416.6 282.5 c 0
  416.6 357.3 388.3 398 326.6 398 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" o.superior
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2092
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" o.sc
+Substitution2: "'sups' Hochgestellte 1" o.superior
 EndChar
 
 StartChar: p
@@ -8251,8 +8251,8 @@ SplineSet
  125 235 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" p.inferior
-Substitution2: "'sups' Hochgestellte 1" p.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" p.sc
+Substitution2: "'sups' Hochgestellte 1" p.superior
 EndChar
 
 StartChar: q
@@ -8291,8 +8291,8 @@ SplineSet
  301.6 -178.5 318.5 -106 334.2 -32 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" q.inferior
-Substitution2: "'sups' Hochgestellte 1" q.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" q.sc
+Substitution2: "'sups' Hochgestellte 1" q.superior
 EndChar
 
 StartChar: r
@@ -8331,8 +8331,8 @@ SplineSet
  236 427 238.480271604 395.946999514 234.250681795 354 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" r.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" r.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B3
 EndChar
 
 StartChar: uni02E2
@@ -8402,8 +8402,8 @@ SplineSet
  179.2 429 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" t.inferior
-Substitution2: "'sups' Hochgestellte 1" t.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" t.sc
+Substitution2: "'sups' Hochgestellte 1" t.superior
 EndChar
 
 StartChar: u
@@ -8448,8 +8448,8 @@ SplineSet
  360.6 64 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" u.inferior
-Substitution2: "'sups' Hochgestellte 1" u.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" u.sc
+Substitution2: "'sups' Hochgestellte 1" u.superior
 EndChar
 
 StartChar: v
@@ -8475,8 +8475,8 @@ SplineSet
  202 0 186 0 176 -3 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" v.inferior
-Substitution2: "'sups' Hochgestellte 1" v.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" v.sc
+Substitution2: "'sups' Hochgestellte 1" v.superior
 EndChar
 
 StartChar: w
@@ -8513,8 +8513,8 @@ SplineSet
  210 -1 188 -1 178 -4 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" w.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B7
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" w.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B7
 EndChar
 
 StartChar: uni02E3
@@ -8605,8 +8605,8 @@ SplineSet
  186.6 76 130.7 343.2 109.8 432 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" y.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B8
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" y.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B8
 EndChar
 
 StartChar: z
@@ -8645,8 +8645,8 @@ SplineSet
  146.5 50 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" z.inferior
-Substitution2: "'sups' Hochgestellte 1" z.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" z.sc
+Substitution2: "'sups' Hochgestellte 1" z.superior
 EndChar
 
 StartChar: braceleft
@@ -9551,8 +9551,8 @@ SplineSet
  202 315 l 1
  217.1 353 226.9 390 238.2 443 c 2
 EndSplineSet
-Ligature2: "'frac' Brueche 1" one slash four
 LCarets2: 2 215 424
+Ligature2: "'frac' Brueche 1" one slash four
 Colour: ff80cc
 EndChar
 
@@ -10665,8 +10665,8 @@ SplineSet
  286.5 550.2 275 495.9 263 442 c 2
  179.3 67 l 2
 EndSplineSet
-Substitution2: "'ss03' Stilgruppe 3 1" germandbls.ss03
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" germandbls.ss03
 EndChar
 
 StartChar: agrave
@@ -12333,10 +12333,10 @@ SplineSet
  113 54 129 125 145 200 c 2
  198 445 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
-Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eng.sc
+Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 Comment: "Sieht in Times anders aus"
 EndChar
 
@@ -16474,8 +16474,8 @@ SplineSet
  792.5 821 l 1
 EndSplineSet
 Refer: 349 198 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Colour: ff00ff
 EndChar
 
@@ -29976,9 +29976,9 @@ SplineSet
  191 315 l 1
  206.1 353 215.9 390 227.2 443 c 2
 EndSplineSet
-Ligature2: "'frac' Brueche 1" one slash three
-Ligature2: "'frac' Brueche 1" one fraction three
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction three
+Ligature2: "'frac' Brueche 1" one slash three
 Colour: ff80cc
 EndChar
 
@@ -30015,9 +30015,9 @@ SplineSet
  534.8 112 569.3 138 578 179 c 0
 EndSplineSet
 Refer: 329 178 N 1 0 0 1 -10.2 -48 2
-Ligature2: "'frac' Brueche 1" two slash three
-Ligature2: "'frac' Brueche 1" two fraction three
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" two fraction three
+Ligature2: "'frac' Brueche 1" two slash three
 Colour: ff80cc
 EndChar
 
@@ -30068,9 +30068,9 @@ SplineSet
  198.2 316 l 1
  213.3 354 223.1 391 234.4 444 c 2
 EndSplineSet
-Ligature2: "'frac' Brueche 1" one slash five
-Ligature2: "'frac' Brueche 1" one fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction five
+Ligature2: "'frac' Brueche 1" one slash five
 Colour: ff80cc
 EndChar
 
@@ -30106,9 +30106,9 @@ SplineSet
  525 -61 550.1 -23 558.8 18 c 0
 EndSplineSet
 Refer: 329 178 N 1 0 0 1 -9.2 -48 2
-Ligature2: "'frac' Brueche 1" two slash five
-Ligature2: "'frac' Brueche 1" two fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" two fraction five
+Ligature2: "'frac' Brueche 1" two slash five
 Colour: ff80cc
 EndChar
 
@@ -30162,9 +30162,9 @@ SplineSet
  446.2 -51 455 -61 477 -61 c 0
  522 -61 547.1 -23 555.8 18 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" three slash five
-Ligature2: "'frac' Brueche 1" three fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three fraction five
+Ligature2: "'frac' Brueche 1" three slash five
 Colour: ff80cc
 EndChar
 
@@ -30220,9 +30220,9 @@ SplineSet
  450.2 -51 459 -61 481 -61 c 0
  526 -61 551.1 -23 559.8 18 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" four slash five
-Ligature2: "'frac' Brueche 1" four fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" four fraction five
+Ligature2: "'frac' Brueche 1" four slash five
 Colour: ff80cc
 EndChar
 
@@ -30256,9 +30256,9 @@ SplineSet
  213.1 353 222.9 390 234.2 443 c 2
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 253.2 -446 2
-Ligature2: "'frac' Brueche 1" one slash eight
-Ligature2: "'frac' Brueche 1" one fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction eight
+Ligature2: "'frac' Brueche 1" one slash eight
 Colour: ff80cc
 EndChar
 
@@ -30317,9 +30317,9 @@ SplineSet
  575 19 577.5 45 541.8 65 c 2
  515.8 79 l 1
 EndSplineSet
-Ligature2: "'frac' Brueche 1" three slash eight
-Ligature2: "'frac' Brueche 1" three fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three fraction eight
+Ligature2: "'frac' Brueche 1" three slash eight
 Colour: ff80cc
 EndChar
 
@@ -30360,9 +30360,9 @@ SplineSet
  510.6 78 l 1
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 -14.2 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" five slash eight
 Ligature2: "'frac' Brueche 1" three fraction eight
-LCarets2: 2 0 0
 Colour: ff80cc
 EndChar
 
@@ -30403,9 +30403,9 @@ SplineSet
  520.8 79 l 1
 EndSplineSet
 Refer: 1076 8311 N 1 0 0 1 -9.2 -48 2
-Ligature2: "'frac' Brueche 1" seven slash eight
-Ligature2: "'frac' Brueche 1" seven fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" seven fraction eight
+Ligature2: "'frac' Brueche 1" seven slash eight
 Colour: ff80cc
 EndChar
 
@@ -30438,8 +30438,8 @@ SplineSet
  195.2 316 l 1
  210.3 354 220.1 391 231.4 444 c 2
 EndSplineSet
-Ligature2: "'frac' Brueche 1" one slash
 Ligature2: "'frac' Brueche 1" one fraction
+Ligature2: "'frac' Brueche 1" one slash
 Colour: ff80cc
 EndChar
 
@@ -33446,9 +33446,9 @@ SplineSet
  48 -171 63.1 -128 84.3 -68 c 0
  103 -15 125.2 121.1 146.8 236 c 2
 EndSplineSet
-Substitution2: "Substitution f short 1" f_f.short
-Ligature2: "'liga' Standardligaturen 1" f f
 LCarets2: 1 284
+Ligature2: "'liga' Standardligaturen 1" f f
+Substitution2: "Substitution f short 1" f_f.short
 EndChar
 
 StartChar: f_i
@@ -37687,8 +37687,8 @@ SplineSet
  297.8 439 299.4 438.9 300.9 438.9 c 1
  268.8 474.9 265.7 511.3 275.6 558 c 0
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" s t
 LCarets2: 1 357
+Ligature2: "'hlig' Historische Ligaturen 1" s t
 Colour: ff80cc
 EndChar
 
@@ -39372,8 +39372,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 10 49 N 1 0 0 1 -10 0 2
-Substitution2: "'tnum' Tabellenziffern 1" one
 Substitution2: "'onum' Minuskelziffern 1" one.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" one
 Colour: ff00ff
 EndChar
 
@@ -39384,8 +39384,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 11 50 N 1 0 0 1 -10 0 2
-Substitution2: "'tnum' Tabellenziffern 1" two
 Substitution2: "'onum' Minuskelziffern 1" two.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" two
 Colour: ff00ff
 EndChar
 
@@ -39396,8 +39396,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 12 51 N 1 0 0 1 0 0 2
-Substitution2: "'tnum' Tabellenziffern 1" three
 Substitution2: "'onum' Minuskelziffern 1" three.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" three
 Colour: ff00ff
 EndChar
 
@@ -39408,8 +39408,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 13 52 N 1 0 0 1 0 0 2
-Substitution2: "'tnum' Tabellenziffern 1" four
 Substitution2: "'onum' Minuskelziffern 1" four.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" four
 Colour: ff00ff
 EndChar
 
@@ -39420,8 +39420,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 14 53 N 1 0 0 1 -10 0 2
-Substitution2: "'tnum' Tabellenziffern 1" five
 Substitution2: "'onum' Minuskelziffern 1" five.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" five
 Colour: ff00ff
 EndChar
 
@@ -39432,8 +39432,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 15 54 N 1 0 0 1 5 0 2
-Substitution2: "'tnum' Tabellenziffern 1" six
 Substitution2: "'onum' Minuskelziffern 1" six.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" six
 Colour: ff00ff
 EndChar
 
@@ -39444,8 +39444,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 2220 56 N 1 0 0 1 0 0 2
-Substitution2: "'tnum' Tabellenziffern 1" eight
 Substitution2: "'onum' Minuskelziffern 1" eight.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" eight
 EndChar
 
 StartChar: two.oldstyle
@@ -42336,9 +42336,9 @@ SplineSet
  218.3 354 228.1 391 239.4 444 c 2
 EndSplineSet
 Refer: 1091 8326 N 1 0 0 1 358.6 31 2
-Ligature2: "'frac' Brueche 1" one slash six
-Ligature2: "'frac' Brueche 1" one fraction six
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction six
+Ligature2: "'frac' Brueche 1" one slash six
 Colour: ff80cc
 EndChar
 
@@ -42357,9 +42357,9 @@ SplineSet
 EndSplineSet
 Refer: 1091 8326 N 1 0 0 1 357.8 32 2
 Refer: 1074 8309 N 1 0 0 1 -11.2 -48 2
-Ligature2: "'frac' Brueche 1" five slash six
-Ligature2: "'frac' Brueche 1" five fraction six
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five fraction six
+Ligature2: "'frac' Brueche 1" five slash six
 Colour: ff80cc
 EndChar
 
@@ -51580,8 +51580,8 @@ SplineSet
  380.2 429 l 1
  467.2 429 l 1
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" f t
 LCarets2: 1 292
+Ligature2: "'liga' Standardligaturen 1" f t
 EndChar
 
 StartChar: uni0360
@@ -51695,8 +51695,8 @@ SplineSet
  498 625 l 1
  456.5 558.1 l 1
 EndSplineSet
-Substitution2: "'tnum' Tabellenziffern 1" zero.slash
 Substitution2: "'onum' Minuskelziffern 1" zero.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" zero.slash
 Colour: ff00ff
 EndChar
 
@@ -51728,8 +51728,8 @@ SplineSet
  562.1 63.3 543.9 49.9 524.5 38.5 c 1
 EndSplineSet
 Refer: 301 117 N 1 0 0 1 685 0 2
-Ligature2: "'liga' Standardligaturen 1" Q u
 LCarets2: 1 698
+Ligature2: "'liga' Standardligaturen 1" Q u
 Colour: ff80cc
 EndChar
 
@@ -51797,9 +51797,9 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 257 48 N 1 0 0 1 18 0 2
-Substitution2: "'zero' gestrichene Null 1" zero.slashfitted
-Substitution2: "'tnum' Tabellenziffern 1" zero
 Substitution2: "'onum' Minuskelziffern 1" zero.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" zero
+Substitution2: "'zero' gestrichene Null 1" zero.slashfitted
 Colour: ff00ff
 EndChar
 
@@ -51821,8 +51821,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 16 55 N 1 0 0 1 -10 0 2
-Substitution2: "'tnum' Tabellenziffern 1" seven
 Substitution2: "'onum' Minuskelziffern 1" seven.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" seven
 Colour: ff00ff
 EndChar
 
@@ -51833,8 +51833,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 17 57 N 1 0 0 1 0 0 2
-Substitution2: "'tnum' Tabellenziffern 1" nine
 Substitution2: "'onum' Minuskelziffern 1" nine.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" nine
 Colour: ff00ff
 EndChar
 
@@ -58124,8 +58124,8 @@ SplineSet
  182.3 130.8 176 107.1 176 82 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" l.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E1
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" l.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E1
 EndChar
 
 StartChar: s
@@ -58161,8 +58161,8 @@ SplineSet
  62.4 96 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" s.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" s.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E2
 EndChar
 
 StartChar: x
@@ -58194,9 +58194,9 @@ SplineSet
  44 0 28 0 17.4 -3 c 1
  228.4 206.8 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni02E3
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2093
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" x.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E3
 EndChar
 
 StartChar: uni03D8
@@ -63909,8 +63909,8 @@ SplineSet
  95 54 107 105 123 179 c 2
  145 281 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle.sc
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 EndChar
 
 StartChar: ohungarumlaut.sc
@@ -64322,10 +64322,10 @@ SplineSet
  142.7 133.8 141.7 122.7 141.7 112.6 c 0
  141.7 47.9 184.9 24 223 24 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2078
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
-Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'onum' Minuskelziffern 1" eight.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
+Substitution2: "'sups' Hochgestellte 1" uni2078
 EndChar
 
 StartChar: uniFFFD
@@ -64423,8 +64423,8 @@ SplineSet
  336 94 l 1
  352.4 49 389.9 35 445.4 35 c 0
 EndSplineSet
-Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 EndChar
 
 StartChar: uni2201
@@ -65263,9 +65263,9 @@ SplineSet
  498 625 l 1
  447.1 542.9 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2070
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
 Substitution2: "'pnum' Proportionalziffern 1" zero.slashfitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
+Substitution2: "'sups' Hochgestellte 1" uni2070
 EndChar
 
 StartChar: germandbls.sc
@@ -65675,9 +65675,9 @@ SplineSet
  144.9 47.9 188.1 24 226.2 24 c 0
 EndSplineSet
 Substitution2: "'lnum' Versalziffern 1" eight.fitted
-Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2078
 Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
+Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 EndChar
 
 StartChar: nine.oldstyle
@@ -66054,8 +66054,8 @@ SplineSet
  365.2 429 l 1
  470.2 429 l 1
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" t t
 LCarets2: 1 306
+Ligature2: "'liga' Standardligaturen 1" t t
 EndChar
 
 StartChar: c_t
@@ -66104,8 +66104,8 @@ SplineSet
  120.9 -10 52.8 79 80.2 208 c 0
  108.3 340.1 227.9 426.3 331.2 438 c 1
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" c t
 LCarets2: 1 407
+Ligature2: "'hlig' Historische Ligaturen 1" c t
 EndChar
 
 StartChar: h.alt

--- a/sources/LibertinusSans-Regular.sfd
+++ b/sources/LibertinusSans-Regular.sfd
@@ -548,9 +548,9 @@ SplineSet
  48 -24 44 207 44 252 c 0
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenleft.sc
+Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208D
 Substitution2: "'sups' Hochgestellte 1" uni207D
-Substitution2: "'case' Versalformen 1" parenleft.sc
 EndChar
 
 StartChar: parenright
@@ -569,9 +569,9 @@ SplineSet
  252 528 256 297 256 252 c 0
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenright.sc
+Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208E
 Substitution2: "'sups' Hochgestellte 1" uni207E
-Substitution2: "'case' Versalformen 1" parenright.sc
 Colour: ff00ff
 EndChar
 
@@ -668,10 +668,10 @@ SplineSet
  292 591 286 551 286 443 c 2
  286 189 l 2
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni00B9
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
-Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'onum' Minuskelziffern 1" one.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" one.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
+Substitution2: "'sups' Hochgestellte 1" uni00B9
 EndChar
 
 StartChar: two
@@ -704,10 +704,10 @@ SplineSet
  315.8 340 327.8 393.2 327.8 434.9 c 0
  327.8 505 274.4 553 222 553 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni00B2
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
-Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'onum' Minuskelziffern 1" two.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" two.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
+Substitution2: "'sups' Hochgestellte 1" uni00B2
 EndChar
 
 StartChar: three
@@ -743,10 +743,10 @@ SplineSet
  92 117 l 1
  119 59 130 29 209 29 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni00B3
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
-Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'onum' Minuskelziffern 1" three.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" three.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
+Substitution2: "'sups' Hochgestellte 1" uni00B3
 EndChar
 
 StartChar: four
@@ -782,10 +782,10 @@ SplineSet
  286 198 l 1
  286 512 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2074
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
-Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'onum' Minuskelziffern 1" four.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" four.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
+Substitution2: "'sups' Hochgestellte 1" uni2074
 EndChar
 
 StartChar: five
@@ -817,10 +817,10 @@ SplineSet
  341 380 406 293 406 196 c 0
  406 78 321 -10 202 -10 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2075
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
-Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'onum' Minuskelziffern 1" five.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" five.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
+Substitution2: "'sups' Hochgestellte 1" uni2075
 EndChar
 
 StartChar: six
@@ -847,10 +847,10 @@ SplineSet
  221 577 294 605 397 611 c 1
  400 583 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2076
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
-Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'onum' Minuskelziffern 1" six.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" six.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
+Substitution2: "'sups' Hochgestellte 1" uni2076
 EndChar
 
 StartChar: seven
@@ -872,10 +872,10 @@ SplineSet
  124 -7 l 1
  191 143 267 332 345 525 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2077
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
-Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'onum' Minuskelziffern 1" seven.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
+Substitution2: "'sups' Hochgestellte 1" uni2077
 EndChar
 
 StartChar: nine
@@ -902,10 +902,10 @@ SplineSet
  239 23 166 -5 63 -11 c 1
  60 17 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2079
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
-Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'onum' Minuskelziffern 1" nine.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
+Substitution2: "'sups' Hochgestellte 1" uni2079
 Colour: ff00ff
 EndChar
 
@@ -2002,8 +2002,8 @@ LayerCount: 2
 Fore
 Refer: 1678 856 N 1 0 0 1 163 141 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 Position2: "'cpsp' Versalabstaende 1" dx=5 dy=0 dh=10 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 Colour: ff00ff
 EndChar
 
@@ -5139,9 +5139,9 @@ SplineSet
  319 363 l 1
  337 332 391 254 437 192 c 1
 EndSplineSet
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ampersand.alt
 Substitution2: "'salt' Stilistische Alternativformen 1" ampersand.alt
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" ampersand.alt
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ampersand.alt
 EndChar
 
 StartChar: quotesingle
@@ -5194,8 +5194,8 @@ SplineSet
  301 261 287 236 274 236 c 2
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" hyphen.sc
-Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 Substitution2: "'case' Versalformen 1" hyphen.cap
+Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 EndChar
 
 StartChar: period
@@ -5234,11 +5234,11 @@ SplineSet
  364 542 421 465 421 309 c 0
  421 75 305 -10 228 -10 c 0
 EndSplineSet
-Substitution2: "'zero' gestrichene Null 1" zero.slash
-Substitution2: "'sups' Hochgestellte 1" uni2070
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
-Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
+Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'zero' gestrichene Null 1" zero.slash
 EndChar
 
 StartChar: I
@@ -5343,8 +5343,8 @@ SplineSet
  104 445 l 2
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=5 dy=0 dh=10 dv=0
-Substitution2: "'ss02' Stilgruppe 2 1" K.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" k.sc
+Substitution2: "'ss02' Stilgruppe 2 1" K.alt
 Colour: ff80cc
 EndChar
 
@@ -5596,8 +5596,8 @@ SplineSet
  426 586 344 609 283 609 c 0
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=5 dy=0 dh=10 dv=0
-Substitution2: "'ss02' Stilgruppe 2 1" R.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" r.sc
+Substitution2: "'ss02' Stilgruppe 2 1" R.alt
 EndChar
 
 StartChar: S
@@ -6002,9 +6002,9 @@ SplineSet
  444 -4 413.2 -10 388 -10 c 0
  351.4 -10 321.5 8.9 310.1 48 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" a.superior
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2090
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" a.sc
+Substitution2: "'sups' Hochgestellte 1" a.superior
 EndChar
 
 StartChar: b
@@ -6039,8 +6039,8 @@ SplineSet
  163.3 626.7 162 574 162 500 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" b.inferior
-Substitution2: "'sups' Hochgestellte 1" b.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" b.sc
+Substitution2: "'sups' Hochgestellte 1" b.superior
 EndChar
 
 StartChar: c
@@ -6071,8 +6071,8 @@ SplineSet
  323.5 370.5 288.5 399 250 399 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" c.inferior
-Substitution2: "'sups' Hochgestellte 1" c.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" c.sc
+Substitution2: "'sups' Hochgestellte 1" c.superior
 EndChar
 
 StartChar: d
@@ -6113,8 +6113,8 @@ SplineSet
  361 58 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" d.inferior
-Substitution2: "'sups' Hochgestellte 1" d.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" d.sc
+Substitution2: "'sups' Hochgestellte 1" d.superior
 EndChar
 
 StartChar: e
@@ -6146,9 +6146,9 @@ SplineSet
  173.5 62 220.8 49 255 49 c 0
  310 49 357 66 392 104 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" e.superior
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2091
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" e.sc
+Substitution2: "'sups' Hochgestellte 1" e.superior
 EndChar
 
 StartChar: f
@@ -6192,10 +6192,10 @@ SplineSet
  28.7 405 34.3 414.7 41 431 c 1
  54.2 429.2 77.3 429 99 429 c 1
 EndSplineSet
-Substitution2: "Substitution f short 1" f.short
 Substitution2: "'sinf' Wissenschaftliche Indices 1" f.inferior
-Substitution2: "'sups' Hochgestellte 1" f.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" f.sc
+Substitution2: "'sups' Hochgestellte 1" f.superior
+Substitution2: "Substitution f short 1" f.short
 EndChar
 
 StartChar: g
@@ -6247,8 +6247,8 @@ SplineSet
  287 176 312 223.3 312 284 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" g.inferior
-Substitution2: "'sups' Hochgestellte 1" g.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" g.sc
+Substitution2: "'sups' Hochgestellte 1" g.superior
 EndChar
 
 StartChar: h
@@ -6291,10 +6291,10 @@ SplineSet
  174.2 626.5 170 575 170 501 c 2
  170 352 l 1
 EndSplineSet
-Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
 Substitution2: "'salt' Stilistische Alternativformen 1" h.alt
-Substitution2: "'sups' Hochgestellte 1" uni02B0
+Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" h.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B0
 EndChar
 
 StartChar: i
@@ -6309,11 +6309,11 @@ LayerCount: 2
 Fore
 Refer: 673 775 N 1 0 0 1 311 22 2
 Refer: 419 305 N 1 0 0 1 0 0 2
-Substitution2: "Substitution dotless forms 1" dotlessi
+Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > i.sc 1" i.sc
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
-Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
 Substitution2: "'sups' Hochgestellte 1" uni2071
+Substitution2: "Substitution dotless forms 1" dotlessi
 Colour: ff00ff
 EndChar
 
@@ -6325,10 +6325,10 @@ LayerCount: 2
 Fore
 Refer: 673 775 N 1 0 0 1 321 22 2
 Refer: 1715 567 N 1 0 0 1 0 0 2
-Substitution2: "Substitution dotless forms 1" uni0237
 Substitution2: "'sinf' Wissenschaftliche Indices 1" j.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" j.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B2
+Substitution2: "Substitution dotless forms 1" uni0237
 Colour: ff00ff
 EndChar
 
@@ -6371,8 +6371,8 @@ SplineSet
  88.5 53.5 90 125.5 90 200 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" k.inferior
-Substitution2: "'sups' Hochgestellte 1" k.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" k.sc
+Substitution2: "'sups' Hochgestellte 1" k.superior
 Colour: ff80cc
 EndChar
 
@@ -6454,8 +6454,8 @@ SplineSet
  162 352 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" m.inferior
-Substitution2: "'sups' Hochgestellte 1" m.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" m.sc
+Substitution2: "'sups' Hochgestellte 1" m.superior
 EndChar
 
 StartChar: n
@@ -6499,8 +6499,8 @@ SplineSet
  462 249 460 212 460 180 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" n.inferior
-Substitution2: "'sups' Hochgestellte 1" uni207F
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" n.sc
+Substitution2: "'sups' Hochgestellte 1" uni207F
 EndChar
 
 StartChar: o
@@ -6528,9 +6528,9 @@ SplineSet
  326 30 374 100.9 374 196 c 0
  374 317 353 399 247 399 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" o.superior
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2092
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" o.sc
+Substitution2: "'sups' Hochgestellte 1" o.superior
 EndChar
 
 StartChar: p
@@ -6569,8 +6569,8 @@ SplineSet
  162 352 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" p.inferior
-Substitution2: "'sups' Hochgestellte 1" p.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" p.sc
+Substitution2: "'sups' Hochgestellte 1" p.superior
 EndChar
 
 StartChar: q
@@ -6607,8 +6607,8 @@ SplineSet
  291 439 347.9 435 366 432 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" q.inferior
-Substitution2: "'sups' Hochgestellte 1" q.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" q.sc
+Substitution2: "'sups' Hochgestellte 1" q.superior
 EndChar
 
 StartChar: r
@@ -6647,8 +6647,8 @@ SplineSet
  167 334 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" r.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" r.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B3
 EndChar
 
 StartChar: uni02E2
@@ -6719,8 +6719,8 @@ SplineSet
  53.4 429.4 74.5 429.1 95 429 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" t.inferior
-Substitution2: "'sups' Hochgestellte 1" t.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" t.sc
+Substitution2: "'sups' Hochgestellte 1" t.superior
 EndChar
 
 StartChar: u
@@ -6765,8 +6765,8 @@ SplineSet
  365 92 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" u.inferior
-Substitution2: "'sups' Hochgestellte 1" u.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" u.sc
+Substitution2: "'sups' Hochgestellte 1" u.superior
 EndChar
 
 StartChar: v
@@ -6793,8 +6793,8 @@ SplineSet
  223 0 212 0 202 -3 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" v.inferior
-Substitution2: "'sups' Hochgestellte 1" v.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" v.sc
+Substitution2: "'sups' Hochgestellte 1" v.superior
 EndChar
 
 StartChar: w
@@ -6831,8 +6831,8 @@ SplineSet
  228 -1 215 -1 205 -4 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" w.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B7
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" w.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B7
 EndChar
 
 StartChar: uni02E3
@@ -6888,8 +6888,8 @@ SplineSet
  186.6 85.1 67.8 343.2 28 432 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" y.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B8
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" y.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B8
 EndChar
 
 StartChar: z
@@ -6928,8 +6928,8 @@ SplineSet
  135.9 45 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" z.inferior
-Substitution2: "'sups' Hochgestellte 1" z.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" z.sc
+Substitution2: "'sups' Hochgestellte 1" z.superior
 EndChar
 
 StartChar: braceleft
@@ -7716,8 +7716,8 @@ SplineSet
 EndSplineSet
 Refer: 1071 8308 N 1 0 0 1 348 -446 2
 Refer: 336 185 N 1 0 0 1 -3 -49 2
-Ligature2: "'frac' Brueche 1" one slash four
 LCarets2: 2 215 424
+Ligature2: "'frac' Brueche 1" one slash four
 Colour: ff80cc
 EndChar
 
@@ -9664,10 +9664,10 @@ SplineSet
  102 54 104 125 104 200 c 2
  104 445 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
-Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
 Position2: "'cpsp' Versalabstaende 1" dx=5 dy=0 dh=10 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eng.sc
+Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 Comment: "Sieht in Times anders aus"
 EndChar
 
@@ -12190,8 +12190,8 @@ LayerCount: 2
 Fore
 Refer: 2339 -1 N 1 0 0 1 775 128 2
 Refer: 349 198 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=5 dy=0 dh=10 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Colour: ff00ff
 EndChar
 
@@ -14106,8 +14106,8 @@ SplineSet
  -228 693 -205 710 -171 710 c 0
  -166 710 -160 709 -156 708 c 1
 EndSplineSet
-Substitution2: "Substitution cap-Accents 1" grave.cap
 Substitution2: "'case' Versalformen 1" grave.cap
+Substitution2: "Substitution cap-Accents 1" grave.cap
 EndChar
 
 StartChar: acutecomb
@@ -14129,8 +14129,8 @@ SplineSet
  -239 572.2 -235.7 576.2 -227.6 589 c 2
  -152 708 l 1
 EndSplineSet
-Substitution2: "Substitution cap-Accents 1" acute.cap
 Substitution2: "'case' Versalformen 1" acute.cap
+Substitution2: "Substitution cap-Accents 1" acute.cap
 EndChar
 
 StartChar: uni0302
@@ -14151,8 +14151,8 @@ SplineSet
  -231 608 -193 651 -164 697 c 1
  -114 697 l 1
 EndSplineSet
-Substitution2: "Substitution cap-Accents 1" circumflex.cap
 Substitution2: "'case' Versalformen 1" circumflex.cap
+Substitution2: "Substitution cap-Accents 1" circumflex.cap
 EndChar
 
 StartChar: tildecomb
@@ -22160,9 +22160,9 @@ SplineSet
 EndSplineSet
 Refer: 336 185 N 1 0 0 1 -14 -49 2
 Refer: 330 179 N 1 0 0 1 358 -443 2
-Ligature2: "'frac' Brueche 1" one slash three
-Ligature2: "'frac' Brueche 1" one fraction three
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction three
+Ligature2: "'frac' Brueche 1" one slash three
 Colour: ff80cc
 EndChar
 
@@ -22181,9 +22181,9 @@ SplineSet
 EndSplineSet
 Refer: 330 179 N 1 0 0 1 352 -445 2
 Refer: 329 178 N 1 0 0 1 0 -48 2
-Ligature2: "'frac' Brueche 1" two slash three
-Ligature2: "'frac' Brueche 1" two fraction three
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" two fraction three
+Ligature2: "'frac' Brueche 1" two slash three
 Colour: ff80cc
 EndChar
 
@@ -22202,9 +22202,9 @@ SplineSet
 EndSplineSet
 Refer: 1072 8309 N 1 0 0 1 351 -445 2
 Refer: 336 185 N 1 0 0 1 -7 -48 2
-Ligature2: "'frac' Brueche 1" one slash five
-Ligature2: "'frac' Brueche 1" one fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction five
+Ligature2: "'frac' Brueche 1" one slash five
 Colour: ff80cc
 EndChar
 
@@ -22223,9 +22223,9 @@ SplineSet
 EndSplineSet
 Refer: 1072 8309 N 1 0 0 1 352 -444 2
 Refer: 329 178 N 1 0 0 1 1 -48 2
-Ligature2: "'frac' Brueche 1" two slash five
-Ligature2: "'frac' Brueche 1" two fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" two fraction five
+Ligature2: "'frac' Brueche 1" two slash five
 Colour: ff80cc
 EndChar
 
@@ -22244,9 +22244,9 @@ SplineSet
 EndSplineSet
 Refer: 1072 8309 N 1 0 0 1 349 -444 2
 Refer: 330 179 N 1 0 0 1 -1 -49 2
-Ligature2: "'frac' Brueche 1" three slash five
-Ligature2: "'frac' Brueche 1" three fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three fraction five
+Ligature2: "'frac' Brueche 1" three slash five
 Colour: ff80cc
 EndChar
 
@@ -22265,9 +22265,9 @@ SplineSet
 EndSplineSet
 Refer: 1072 8309 N 1 0 0 1 353 -444 2
 Refer: 1071 8308 N 1 0 0 1 -9 -48 2
-Ligature2: "'frac' Brueche 1" four slash five
-Ligature2: "'frac' Brueche 1" four fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" four fraction five
+Ligature2: "'frac' Brueche 1" four slash five
 Colour: ff80cc
 EndChar
 
@@ -22286,9 +22286,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8312 N 1 0 0 1 348 -446 2
 Refer: 336 185 N 1 0 0 1 -7 -49 2
-Ligature2: "'frac' Brueche 1" one slash eight
-Ligature2: "'frac' Brueche 1" one fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction eight
+Ligature2: "'frac' Brueche 1" one slash eight
 Colour: ff80cc
 EndChar
 
@@ -22307,9 +22307,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8312 N 1 0 0 1 347 -444 2
 Refer: 330 179 N 1 0 0 1 2 -50 2
-Ligature2: "'frac' Brueche 1" three slash eight
-Ligature2: "'frac' Brueche 1" three fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three fraction eight
+Ligature2: "'frac' Brueche 1" three slash eight
 Colour: ff80cc
 EndChar
 
@@ -22328,9 +22328,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8312 N 1 0 0 1 342 -445 2
 Refer: 1072 8309 N 1 0 0 1 -4 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" five slash eight
 Ligature2: "'frac' Brueche 1" three fraction eight
-LCarets2: 2 0 0
 Colour: ff80cc
 EndChar
 
@@ -22349,9 +22349,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8312 N 1 0 0 1 352 -444 2
 Refer: 1074 8311 N 1 0 0 1 1 -48 2
-Ligature2: "'frac' Brueche 1" seven slash eight
-Ligature2: "'frac' Brueche 1" seven fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" seven fraction eight
+Ligature2: "'frac' Brueche 1" seven slash eight
 Colour: ff80cc
 EndChar
 
@@ -22369,8 +22369,8 @@ SplineSet
  532 601 l 1
 EndSplineSet
 Refer: 336 185 N 1 0 0 1 -10 -48 2
-Ligature2: "'frac' Brueche 1" one slash
 Ligature2: "'frac' Brueche 1" one fraction
+Ligature2: "'frac' Brueche 1" one slash
 Colour: ff80cc
 EndChar
 
@@ -25111,9 +25111,9 @@ SplineSet
  97.5 53.5 99 125.5 99 200 c 2
  99 385 l 1
 EndSplineSet
-Substitution2: "Substitution f short 1" f_f.short
-Ligature2: "'liga' Standardligaturen 1" f f
 LCarets2: 1 284
+Ligature2: "'liga' Standardligaturen 1" f f
+Substitution2: "Substitution f short 1" f_f.short
 EndChar
 
 StartChar: f_i
@@ -29009,8 +29009,8 @@ SplineSet
  386 390 l 1
  395.7 405 401.3 414.7 408 431 c 1
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" s t
 LCarets2: 1 357
+Ligature2: "'hlig' Historische Ligaturen 1" s t
 Colour: ff80cc
 EndChar
 
@@ -29693,8 +29693,8 @@ SplineSet
  -231 529 -282 579 -296 664 c 1
  -269 676 l 1
 EndSplineSet
-Substitution2: "Substitution cap-Accents 1" breve.cap
 Substitution2: "'case' Versalformen 1" breve.cap
+Substitution2: "Substitution cap-Accents 1" breve.cap
 EndChar
 
 StartChar: uni0304
@@ -30617,8 +30617,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 10 49 N 1 0 0 1 -42 0 2
-Substitution2: "'tnum' Tabellenziffern 1" one
 Substitution2: "'onum' Minuskelziffern 1" one.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" one
 Colour: ff00ff
 EndChar
 
@@ -30629,8 +30629,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 11 50 N 1 0 0 1 0 0 2
-Substitution2: "'tnum' Tabellenziffern 1" two
 Substitution2: "'onum' Minuskelziffern 1" two.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" two
 Colour: ff00ff
 EndChar
 
@@ -30641,8 +30641,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 12 51 N 1 0 0 1 -10 -2 2
-Substitution2: "'tnum' Tabellenziffern 1" three
 Substitution2: "'onum' Minuskelziffern 1" three.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" three
 Colour: ff00ff
 EndChar
 
@@ -30653,8 +30653,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 13 52 N 1 0 0 1 11 0 2
-Substitution2: "'tnum' Tabellenziffern 1" four
 Substitution2: "'onum' Minuskelziffern 1" four.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" four
 Colour: ff00ff
 EndChar
 
@@ -30665,8 +30665,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 14 53 N 1 0 0 1 -2 0 2
-Substitution2: "'tnum' Tabellenziffern 1" five
 Substitution2: "'onum' Minuskelziffern 1" five.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" five
 Colour: ff00ff
 EndChar
 
@@ -30677,8 +30677,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 15 54 N 1 0 0 1 -3 0 2
-Substitution2: "'tnum' Tabellenziffern 1" six
 Substitution2: "'onum' Minuskelziffern 1" six.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" six
 Colour: ff00ff
 EndChar
 
@@ -30689,8 +30689,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 2181 56 N 1 0 0 1 0 0 2
-Substitution2: "'tnum' Tabellenziffern 1" eight
 Substitution2: "'onum' Minuskelziffern 1" eight.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" eight
 EndChar
 
 StartChar: two.oldstyle
@@ -32564,9 +32564,9 @@ SplineSet
 EndSplineSet
 Refer: 1073 8310 N 1 0 0 1 345 -445 2
 Refer: 336 185 N 1 0 0 1 -2 -48 2
-Ligature2: "'frac' Brueche 1" one slash six
-Ligature2: "'frac' Brueche 1" one fraction six
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction six
+Ligature2: "'frac' Brueche 1" one slash six
 Colour: ff80cc
 EndChar
 
@@ -32585,9 +32585,9 @@ SplineSet
 EndSplineSet
 Refer: 1073 8310 N 1 0 0 1 344 -444 2
 Refer: 1072 8309 N 1 0 0 1 -1 -48 2
-Ligature2: "'frac' Brueche 1" five slash six
-Ligature2: "'frac' Brueche 1" five fraction six
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five fraction six
+Ligature2: "'frac' Brueche 1" five slash six
 Colour: ff80cc
 EndChar
 
@@ -41071,8 +41071,8 @@ SplineSet
  97.5 53.5 99 125.5 99 200 c 2
  99 385 l 1
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" f t
 LCarets2: 1 298
+Ligature2: "'liga' Standardligaturen 1" f t
 EndChar
 
 StartChar: uni0360
@@ -41177,8 +41177,8 @@ SplineSet
  372 628 l 1
  345.8 564.4 l 1
 EndSplineSet
-Substitution2: "'tnum' Tabellenziffern 1" zero.slash
 Substitution2: "'onum' Minuskelziffern 1" zero.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" zero.slash
 Colour: ff00ff
 EndChar
 
@@ -41206,8 +41206,8 @@ SplineSet
  689 194.6 630.8 87.9 534.7 32.2 c 1
 EndSplineSet
 Refer: 301 117 N 1 0 0 1 726 0 2
-Ligature2: "'liga' Standardligaturen 1" Q u
 LCarets2: 1 708
+Ligature2: "'liga' Standardligaturen 1" Q u
 Colour: ff80cc
 EndChar
 
@@ -41218,9 +41218,9 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 257 48 N 1 0 0 1 7 0 2
-Substitution2: "'zero' gestrichene Null 1" zero.slashfitted
-Substitution2: "'tnum' Tabellenziffern 1" zero
 Substitution2: "'onum' Minuskelziffern 1" zero.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" zero
+Substitution2: "'zero' gestrichene Null 1" zero.slashfitted
 Colour: ff00ff
 EndChar
 
@@ -41242,8 +41242,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 16 55 N 1 0 0 1 -32 0 2
-Substitution2: "'tnum' Tabellenziffern 1" seven
 Substitution2: "'onum' Minuskelziffern 1" seven.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" seven
 Colour: ff00ff
 EndChar
 
@@ -41254,8 +41254,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 17 57 N 1 0 0 1 8 0 2
-Substitution2: "'tnum' Tabellenziffern 1" nine
 Substitution2: "'onum' Minuskelziffern 1" nine.oldstyle
+Substitution2: "'tnum' Tabellenziffern 1" nine
 Colour: ff00ff
 EndChar
 
@@ -46544,8 +46544,8 @@ SplineSet
  88.5 53.5 90 125.5 90 200 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" l.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E1
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" l.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E1
 EndChar
 
 StartChar: s
@@ -46580,8 +46580,8 @@ SplineSet
  50 101 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" s.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" s.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E2
 EndChar
 
 StartChar: x
@@ -46613,9 +46613,9 @@ SplineSet
  54 0 37.8 -1.2 28 -3 c 1
  184.5 206.8 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni02E3
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2093
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" x.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E3
 EndChar
 
 StartChar: uni03D8
@@ -50009,8 +50009,8 @@ SplineSet
  84 54 85 105 85 179 c 2
  85 281 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle.sc
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 EndChar
 
 StartChar: ohungarumlaut.sc
@@ -50278,10 +50278,10 @@ SplineSet
  125 243 117 176 117 146 c 0
  117 56 182 24 228 24 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2078
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
-Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'onum' Minuskelziffern 1" eight.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
+Substitution2: "'sups' Hochgestellte 1" uni2078
 EndChar
 
 StartChar: uniFFFD
@@ -50380,8 +50380,8 @@ SplineSet
  342 49 382.5 33 438 33 c 0
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=5 dy=0 dh=10 dv=0
-Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 EndChar
 
 StartChar: uni2201
@@ -51162,9 +51162,9 @@ SplineSet
  372 628 l 1
  343.6 559.1 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni2070
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
 Substitution2: "'pnum' Proportionalziffern 1" zero.slashfitted
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
+Substitution2: "'sups' Hochgestellte 1" uni2070
 EndChar
 
 StartChar: germandbls.sc
@@ -51470,9 +51470,9 @@ LayerCount: 2
 Fore
 Refer: 2181 56 N 1 0 0 1 0 0 2
 Substitution2: "'lnum' Versalziffern 1" eight.fitted
-Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2078
 Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
+Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 EndChar
 
 StartChar: nine.oldstyle
@@ -51825,8 +51825,8 @@ SplineSet
  384 116 387 188 387 248 c 2
  387 385 l 1
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" t t
 LCarets2: 1 294
+Ligature2: "'liga' Standardligaturen 1" t t
 EndChar
 
 StartChar: c_t
@@ -51879,8 +51879,8 @@ SplineSet
  442 390 l 1
  451.7 405 457.3 414.7 464 431 c 1
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" c t
 LCarets2: 1 407
+Ligature2: "'hlig' Historische Ligaturen 1" c t
 EndChar
 
 StartChar: h.alt

--- a/sources/LibertinusSerif-Bold.sfd
+++ b/sources/LibertinusSerif-Bold.sfd
@@ -490,8 +490,8 @@ SplineSet
  268 -213 l 1
  41 -17 36 208 36 253 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenleft.sc
+Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208D
 Substitution2: "'sups' Hochgestellte 1" uni207D
 EndChar
@@ -511,8 +511,8 @@ SplineSet
  47 717 l 1
  274 521 279 296 279 251 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenright.sc
+Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208E
 Substitution2: "'sups' Hochgestellte 1" uni207E
 EndChar
@@ -612,8 +612,8 @@ SplineSet
  367 122 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" one.cap
-Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'onum' Minuskelziffern 1" one.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
 Substitution2: "'sups' Hochgestellte 1" uni00B9
 EndChar
@@ -650,8 +650,8 @@ SplineSet
  73 400 50 429 50 454 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" two.cap
-Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'onum' Minuskelziffern 1" two.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
 Substitution2: "'sups' Hochgestellte 1" uni00B2
 EndChar
@@ -689,8 +689,8 @@ SplineSet
  310.9 543.7 290.2 568 248 568 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" three.cap
-Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'onum' Minuskelziffern 1" three.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
 Substitution2: "'sups' Hochgestellte 1" uni00B3
 EndChar
@@ -729,8 +729,8 @@ SplineSet
  483 209 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" four.cap
-Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'onum' Minuskelziffern 1" four.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
 Substitution2: "'sups' Hochgestellte 1" uni2074
 EndChar
@@ -765,8 +765,8 @@ SplineSet
  288 34 323 90 323 188 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" five.cap
-Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'onum' Minuskelziffern 1" five.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
 Substitution2: "'sups' Hochgestellte 1" uni2075
 EndChar
@@ -796,8 +796,8 @@ SplineSet
  451.8 600.4 453.1 581.2 450 569 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" six.cap
-Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'onum' Minuskelziffern 1" six.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
 Substitution2: "'sups' Hochgestellte 1" uni2076
 EndChar
@@ -824,8 +824,8 @@ SplineSet
  184 498 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" seven.cap
-Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'onum' Minuskelziffern 1" seven.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
 Substitution2: "'sups' Hochgestellte 1" uni2077
 EndChar
@@ -855,8 +855,8 @@ SplineSet
  70.2 -0.4 68.9 18.8 72 31 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" nine.cap
-Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'onum' Minuskelziffern 1" nine.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
 Substitution2: "'sups' Hochgestellte 1" uni2079
 EndChar
@@ -1035,8 +1035,8 @@ SplineSet
  229 235 223 231 218 218 c 2
  165 79 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" a.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" a.sc
 EndChar
 
 StartChar: B
@@ -1079,8 +1079,8 @@ SplineSet
  9 619 9 641 19 647 c 1
  19 647 133 645 173 645 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" b.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" b.sc
 EndChar
 
 StartChar: C
@@ -1109,8 +1109,8 @@ SplineSet
  629 146 646 134 651 125 c 1
  583 36 494 -10 397 -10 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" c.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" c.sc
 EndChar
 
 StartChar: D
@@ -1145,8 +1145,8 @@ SplineSet
  534.3 20.2 434.5 -2 347 -2 c 0
  307 -2 225 0 185 0 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" d.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" d.sc
 EndChar
 
 StartChar: E
@@ -1194,8 +1194,8 @@ SplineSet
  242 365 l 1
  323 365 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" e.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" e.sc
 EndChar
 
 StartChar: F
@@ -1239,8 +1239,8 @@ SplineSet
  242 299 l 1
  242 122 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" f.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" f.sc
 EndChar
 
 StartChar: G
@@ -1280,8 +1280,8 @@ SplineSet
  33 415 72 505 139 565 c 0
  208 627 297 658 395 658 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" g.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" g.sc
 EndChar
 
 StartChar: grave
@@ -1525,8 +1525,8 @@ SplineSet
  443 -172 467 -169 482 -154 c 1
  497 -177 l 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eogonek.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eogonek.sc
 EndChar
 
 StartChar: eogonek
@@ -1575,8 +1575,8 @@ LayerCount: 2
 Fore
 Refer: 2231 -1 N 1 0 0 1 488 0 2
 Refer: 692 917 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ecaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ecaron.sc
 EndChar
 
 StartChar: ecaron
@@ -1619,8 +1619,8 @@ LayerCount: 2
 Fore
 Refer: 2232 -1 N 1 0 0 1 550 0 2
 Refer: 30 71 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" gbreve.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" gbreve.sc
 EndChar
 
 StartChar: gbreve
@@ -1968,8 +1968,8 @@ LayerCount: 2
 Fore
 Refer: 2227 -1 N 1 0 0 1 36 0 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 EndChar
 
 StartChar: uni0408
@@ -5145,8 +5145,8 @@ SplineSet
  312 294 320 284 320 273 c 0
  320 260 296 215 273 215 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" hyphen.cap
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" hyphen.sc
+Substitution2: "'case' Versalformen 1" hyphen.cap
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 EndChar
 
@@ -5184,11 +5184,11 @@ SplineSet
  484 69 354 -10 255 -10 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" zero.cap
-Substitution2: "'zero' gestrichene Null 1" zero.slash
-Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
 Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'zero' gestrichene Null 1" zero.slash
 EndChar
 
 StartChar: I
@@ -5218,8 +5218,8 @@ SplineSet
  86 35 114 39 114 122 c 2
  114 523 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" i.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=6 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" i.sc
 EndChar
 
 StartChar: J
@@ -5248,8 +5248,8 @@ SplineSet
  364 641 364 619 358 613 c 1
  298 610 281 605 281 522 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" j.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" j.sc
 EndChar
 
 StartChar: K
@@ -5300,8 +5300,8 @@ SplineSet
  80 35 108 39 108 122 c 2
  108 523 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" k.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" k.sc
 EndChar
 
 StartChar: L
@@ -5336,8 +5336,8 @@ SplineSet
  254 61 268 42 289 42 c 2
  349 42 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" l.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" l.sc
 EndChar
 
 StartChar: M
@@ -5384,8 +5384,8 @@ SplineSet
  593 4 593 26 599 32 c 1
  664 35 667.7 35 662.7 116 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" m.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" m.sc
 EndChar
 
 StartChar: N
@@ -5429,8 +5429,8 @@ SplineSet
  626 102 l 2
  626 71 631 0 631 0 c 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" n.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" n.sc
 EndChar
 
 StartChar: O
@@ -5458,8 +5458,8 @@ SplineSet
  176.2 615.3 262.6 658 363 658 c 0
  546 658 694 528 694 329 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" o.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" o.sc
 EndChar
 
 StartChar: P
@@ -5497,8 +5497,8 @@ SplineSet
  21 619 21 641 31 647 c 1
  71 647 306 654 346 654 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" p.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" p.sc
 EndChar
 
 StartChar: Q
@@ -5537,8 +5537,8 @@ SplineSet
  176.2 615.3 262.6 658 363 658 c 0
  546 658 694 528 694 329 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" q.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" q.sc
 EndChar
 
 StartChar: R
@@ -5581,8 +5581,8 @@ SplineSet
  21 619 21 641 31 647 c 1
  71 647 322 654 362 654 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" r.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" r.sc
 EndChar
 
 StartChar: S
@@ -5619,8 +5619,8 @@ SplineSet
  147.7 643.6 206.6 658 252 658 c 0
  345 658 366 639 421 631 c 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" s.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" s.sc
 EndChar
 
 StartChar: T
@@ -5660,8 +5660,8 @@ SplineSet
  415 604 405 567 405 503 c 2
  405 123 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" t.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" t.sc
 EndChar
 
 StartChar: U
@@ -5699,8 +5699,8 @@ SplineSet
  325 641 325 619 319 613 c 1
  242 610 227 605 227 522 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" u.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" u.sc
 EndChar
 
 StartChar: V
@@ -5737,8 +5737,8 @@ SplineSet
  700 641 700 619 694 613 c 1
  650 610 618.1 603.2 594 543 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" v.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" v.sc
 EndChar
 
 StartChar: W
@@ -5783,8 +5783,8 @@ SplineSet
  514.6 613 l 1
  527.5 608.8 556.3 608.8 574.5 613 c 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" w.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" w.sc
 EndChar
 
 StartChar: X
@@ -5837,8 +5837,8 @@ SplineSet
  404 5 404 27 410 33 c 1
  466 36 459.2 53.7 434 89 c 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" x.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" x.sc
 EndChar
 
 StartChar: Y
@@ -5880,8 +5880,8 @@ SplineSet
  391 329.4 387 307.5 387 267.7 c 2
  387 122 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" y.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" y.sc
 EndChar
 
 StartChar: Z
@@ -5921,8 +5921,8 @@ SplineSet
  200 53 198 44 229 44 c 2
  429 44 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" z.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" z.sc
 EndChar
 
 StartChar: bracketleft
@@ -5942,8 +5942,8 @@ SplineSet
  348 -169 348 -187 342 -193 c 1
  97 -193 l 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" bracketleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" bracketleft.sc
+Substitution2: "'case' Versalformen 1" bracketleft.sc
 EndChar
 
 StartChar: backslash
@@ -5978,8 +5978,8 @@ SplineSet
  51 677 51 695 57 701 c 1
  302 701 l 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" bracketright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" bracketright.sc
+Substitution2: "'case' Versalformen 1" bracketright.sc
 EndChar
 
 StartChar: uni02C4
@@ -6045,8 +6045,8 @@ SplineSet
  290 218 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2090
-Substitution2: "'sups' Hochgestellte 1" uni1D43
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" a.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D43
 EndChar
 
 StartChar: b
@@ -6083,8 +6083,8 @@ SplineSet
  258.5 373 237 369.5 204 348 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" b.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D47
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" b.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D47
 EndChar
 
 StartChar: c
@@ -6116,8 +6116,8 @@ SplineSet
  420 118 422 99 422 87 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" c.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D9C
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" c.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D9C
 EndChar
 
 StartChar: d
@@ -6162,8 +6162,8 @@ SplineSet
  359 7 356.8 24.4 354.7 48 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" d.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D48
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" d.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D48
 EndChar
 
 StartChar: e
@@ -6199,8 +6199,8 @@ SplineSet
  336 76 390 87 431 129 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2091
-Substitution2: "'sups' Hochgestellte 1" uni1D49
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" e.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D49
 EndChar
 
 StartChar: f
@@ -6243,8 +6243,8 @@ SplineSet
  230 128 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" f.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1DA0
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" f.sc
+Substitution2: "'sups' Hochgestellte 1" uni1DA0
 EndChar
 
 StartChar: g
@@ -6298,8 +6298,8 @@ SplineSet
  511 406 495 394 467 394 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" g.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D4D
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" g.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D4D
 EndChar
 
 StartChar: h
@@ -6343,8 +6343,8 @@ SplineSet
  528 128 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B0
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" h.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B0
 EndChar
 
 StartChar: i
@@ -6361,9 +6361,9 @@ Fore
 Refer: 419 305 N 1 0 0 1 0 0 2
 Refer: 673 775 N 1 0 0 1 331 0 2
 Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
-Substitution2: "'sups' Hochgestellte 1" uni2071
-Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > i.sc 1" i.sc
+Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
+Substitution2: "'sups' Hochgestellte 1" uni2071
 EndChar
 
 StartChar: j
@@ -6377,8 +6377,8 @@ Fore
 Refer: 1719 567 N 1 0 0 1 0 0 2
 Refer: 673 775 N 1 0 0 1 329 0 2
 Substitution2: "'sinf' Wissenschaftliche Indices 1" j.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" j.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B2
 EndChar
 
 StartChar: k
@@ -6429,8 +6429,8 @@ SplineSet
  84 35 100 44 100 127 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" k.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D4F
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" k.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D4F
 EndChar
 
 StartChar: uni02E1
@@ -6515,8 +6515,8 @@ SplineSet
  228 122 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" m.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D50
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" m.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D50
 EndChar
 
 StartChar: n
@@ -6559,8 +6559,8 @@ SplineSet
  228 122 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" n.inferior
-Substitution2: "'sups' Hochgestellte 1" uni207F
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" n.sc
+Substitution2: "'sups' Hochgestellte 1" uni207F
 EndChar
 
 StartChar: o
@@ -6590,8 +6590,8 @@ SplineSet
  140.6 -10 37 76.4 37 207 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2092
-Substitution2: "'sups' Hochgestellte 1" uni1D52
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" o.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D52
 EndChar
 
 StartChar: p
@@ -6634,8 +6634,8 @@ SplineSet
  225 65 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" p.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D56
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" p.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D56
 EndChar
 
 StartChar: q
@@ -6675,8 +6675,8 @@ SplineSet
  300 46 334 56 353 71 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" q.inferior
-Substitution2: "'sups' Hochgestellte 1" q.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" q.sc
+Substitution2: "'sups' Hochgestellte 1" q.superior
 EndChar
 
 StartChar: r
@@ -6715,8 +6715,8 @@ SplineSet
  239 318.5 228 304 228 268.3 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" r.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" r.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B3
 EndChar
 
 StartChar: uni02E2
@@ -6792,8 +6792,8 @@ SplineSet
  33.7 430 49 433.9 63 434 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" t.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D57
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" t.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D57
 EndChar
 
 StartChar: u
@@ -6837,8 +6837,8 @@ SplineSet
  510 133 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" u.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D58
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" u.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D58
 EndChar
 
 StartChar: v
@@ -6874,8 +6874,8 @@ SplineSet
  402.8 382.1 396 398 342 402 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" v.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D5B
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" v.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D5B
 EndChar
 
 StartChar: w
@@ -6919,8 +6919,8 @@ SplineSet
  451 423 463.1 378.6 481.9 331 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" w.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B7
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" w.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B7
 EndChar
 
 StartChar: uni02E3
@@ -7014,8 +7014,8 @@ SplineSet
  273 -104 257.8 -139.9 242 -168 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" y.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B8
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" y.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B8
 EndChar
 
 StartChar: z
@@ -7055,8 +7055,8 @@ SplineSet
  55 442.4 58.6 446 61 446 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" z.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1DBB
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" z.sc
+Substitution2: "'sups' Hochgestellte 1" uni1DBB
 EndChar
 
 StartChar: braceleft
@@ -7084,8 +7084,8 @@ SplineSet
  294 701 294 689 288 683 c 1
  250 672 203 654.9 208 552 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" braceleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" braceleft.sc
+Substitution2: "'case' Versalformen 1" braceleft.sc
 EndChar
 
 StartChar: bar
@@ -7128,8 +7128,8 @@ SplineSet
  13 -205 13 -193 19 -187 c 1
  57 -176 104 -158.9 99 -56 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" braceright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" braceright.sc
+Substitution2: "'case' Versalformen 1" braceright.sc
 EndChar
 
 StartChar: asciitilde
@@ -7185,8 +7185,8 @@ SplineSet
  60 412 94 444 134 444 c 0
  174 444 206 414 206 376 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" exclamdown.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" exclamdown.sc
+Substitution2: "'case' Versalformen 1" exclamdown.sc
 EndChar
 
 StartChar: cent
@@ -7520,8 +7520,8 @@ SplineSet
  470 35 455.5 26 446 23 c 1
  375.1 106.7 329.9 145.9 262 207 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guillemotleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guillemotleft.sc
+Substitution2: "'case' Versalformen 1" guillemotleft.sc
 EndChar
 
 StartChar: logicalnot
@@ -7882,8 +7882,8 @@ SplineSet
  85 395 99.5 404 109 407 c 1
  179.9 323.3 225.1 284.1 293 223 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guillemotright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guillemotright.sc
+Substitution2: "'case' Versalformen 1" guillemotright.sc
 EndChar
 
 StartChar: onequarter
@@ -7901,8 +7901,8 @@ SplineSet
 EndSplineSet
 Refer: 1073 8308 N 1 0 0 1 348 -499 2
 Refer: 336 185 N 1 0 0 1 -3 -49 2
-Ligature2: "'frac' Brueche 1" one slash four
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one slash four
 EndChar
 
 StartChar: onehalf
@@ -7920,8 +7920,8 @@ SplineSet
 EndSplineSet
 Refer: 336 185 N 1 0 0 1 -1 -49 2
 Refer: 329 178 N 1 0 0 1 358 -443 2
-Ligature2: "'frac' Brueche 1" one slash two
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one slash two
 EndChar
 
 StartChar: threequarters
@@ -7939,8 +7939,8 @@ SplineSet
 EndSplineSet
 Refer: 1073 8308 N 1 0 0 1 352 -497 2
 Refer: 330 179 N 1 0 0 1 -2 -51 2
-Ligature2: "'frac' Brueche 1" three slash four
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three slash four
 EndChar
 
 StartChar: questiondown
@@ -7973,8 +7973,8 @@ SplineSet
  139 408 173 440 213 440 c 0
  253 440 285 410 285 372 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" questiondown.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" questiondown.sc
+Substitution2: "'case' Versalformen 1" questiondown.sc
 EndChar
 
 StartChar: Agrave
@@ -8012,8 +8012,8 @@ SplineSet
  165 79 l 2
 EndSplineSet
 Refer: 2228 -1 N 1 0 0 1 501 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" agrave.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" agrave.sc
 EndChar
 
 StartChar: Aacute
@@ -8024,8 +8024,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 574 0 2
 Refer: 24 65 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aacute.sc
 EndChar
 
 StartChar: Acircumflex
@@ -8037,8 +8037,8 @@ LayerCount: 2
 Fore
 Refer: 2230 -1 N 1 0 0 1 510 0 2
 Refer: 24 65 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" acircumflex.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" acircumflex.sc
 EndChar
 
 StartChar: Atilde
@@ -8050,8 +8050,8 @@ LayerCount: 2
 Fore
 Refer: 672 771 N 1 0 0 1 506 173 2
 Refer: 24 65 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" atilde.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" atilde.sc
 EndChar
 
 StartChar: Adieresis.alt
@@ -8087,8 +8087,8 @@ LayerCount: 2
 Fore
 Refer: 1413 778 N 1 0 0 1 538 95 2
 Refer: 24 65 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aring.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aring.sc
 EndChar
 
 StartChar: AE
@@ -8151,8 +8151,8 @@ SplineSet
  449 571 437 578 420 546 c 2
  297 316 l 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ae.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ae.sc
 EndChar
 
 StartChar: Ccedilla
@@ -8188,8 +8188,8 @@ SplineSet
  370 -190 390 -176 390 -149 c 0
  390 -111.4 337 -107 301 -105 c 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ccedilla.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ccedilla.sc
 EndChar
 
 StartChar: Egrave
@@ -8236,8 +8236,8 @@ SplineSet
  323 365 l 2
 EndSplineSet
 Refer: 2228 -1 N 1 0 0 1 450 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" egrave.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" egrave.sc
 EndChar
 
 StartChar: Eacute
@@ -8250,8 +8250,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 500 0 2
 Refer: 692 917 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eacute.sc
 EndChar
 
 StartChar: Ecircumflex
@@ -8265,8 +8265,8 @@ LayerCount: 2
 Fore
 Refer: 2230 -1 N 1 0 0 1 446 0 2
 Refer: 692 917 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ecircumflex.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ecircumflex.sc
 EndChar
 
 StartChar: Edieresis
@@ -8279,8 +8279,8 @@ LayerCount: 2
 Fore
 Refer: 2225 -1 N 1 0 0 1 538 17 2
 Refer: 692 917 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" edieresis.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" edieresis.sc
 EndChar
 
 StartChar: Igrave
@@ -8307,8 +8307,8 @@ SplineSet
  114 523 l 2
 EndSplineSet
 Refer: 2228 -1 N 1 0 0 1 360 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" igrave.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" igrave.sc
 EndChar
 
 StartChar: Iacute
@@ -8319,8 +8319,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 380 0 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" iacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" iacute.sc
 EndChar
 
 StartChar: Icircumflex
@@ -8332,8 +8332,8 @@ LayerCount: 2
 Fore
 Refer: 2230 -1 N 1 0 0 1 309 0 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" icircumflex.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" icircumflex.sc
 EndChar
 
 StartChar: Idieresis
@@ -8345,8 +8345,8 @@ LayerCount: 2
 Fore
 Refer: 2225 -1 N 1 0 0 1 423 0 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idieresis.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idieresis.sc
 EndChar
 
 StartChar: Eth
@@ -8385,8 +8385,8 @@ SplineSet
  534.3 20.2 434.5 -2 347 -2 c 0
  307 -2 225 0 185 0 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eth.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eth.sc
 EndChar
 
 StartChar: Ntilde
@@ -8398,8 +8398,8 @@ LayerCount: 2
 Fore
 Refer: 672 771 N 1 0 0 1 501 194 2
 Refer: 263 78 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ntilde.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ntilde.sc
 EndChar
 
 StartChar: Ograve
@@ -8427,8 +8427,8 @@ SplineSet
  546 658 694 528 694 329 c 0
 EndSplineSet
 Refer: 2228 -1 N 1 0 0 1 540 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ograve.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ograve.sc
 EndChar
 
 StartChar: Oacute
@@ -8443,8 +8443,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 560 0 2
 Refer: 264 79 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" oacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" oacute.sc
 EndChar
 
 StartChar: Ocircumflex
@@ -8459,8 +8459,8 @@ LayerCount: 2
 Fore
 Refer: 2230 -1 N 1 0 0 1 496 0 2
 Refer: 264 79 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ocircumflex.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ocircumflex.sc
 EndChar
 
 StartChar: Otilde
@@ -8475,8 +8475,8 @@ LayerCount: 2
 Fore
 Refer: 672 771 N 1 0 0 1 494 173 2
 Refer: 264 79 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" otilde.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" otilde.sc
 EndChar
 
 StartChar: Odieresis.alt
@@ -8562,8 +8562,8 @@ SplineSet
  485 32 543 141.9 543 308 c 0
  543 377.5 533.1 435.5 515.7 481.7 c 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" oslash.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" oslash.sc
 EndChar
 
 StartChar: Ugrave
@@ -8599,8 +8599,8 @@ SplineSet
  242 610 227 605 227 522 c 2
 EndSplineSet
 Refer: 2228 -1 N 1 0 0 1 540 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ugrave.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ugrave.sc
 EndChar
 
 StartChar: Uacute
@@ -8612,8 +8612,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 600 0 2
 Refer: 270 85 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uacute.sc
 EndChar
 
 StartChar: Ucircumflex
@@ -8625,8 +8625,8 @@ LayerCount: 2
 Fore
 Refer: 2230 -1 N 1 0 0 1 516 0 2
 Refer: 270 85 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ucircumflex.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ucircumflex.sc
 EndChar
 
 StartChar: Udieresis.alt
@@ -8684,8 +8684,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 570 0 2
 Refer: 274 89 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" yacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" yacute.sc
 EndChar
 
 StartChar: Thorn
@@ -8723,8 +8723,8 @@ SplineSet
  321.8 482 277.1 477.6 254 477.6 c 1
  254 194.4 l 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" thorn.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" thorn.sc
 EndChar
 
 StartChar: germandbls
@@ -8769,8 +8769,8 @@ SplineSet
  17 4 17 26 23 32 c 1
  84 35 100 44 100 126 c 2
 EndSplineSet
-Substitution2: "'ss03' Stilgruppe 3 1" germandbls.ss03
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" germandbls.ss03
 EndChar
 
 StartChar: agrave
@@ -9218,8 +9218,8 @@ LayerCount: 2
 Fore
 Refer: 2232 -1 N 1 0 0 1 530 0 2
 Refer: 24 65 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" abreve.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" abreve.sc
 EndChar
 
 StartChar: abreve
@@ -9276,8 +9276,8 @@ SplineSet
  247.8 296.3 l 2
  244 286 251 283 273 283 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aogonek.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aogonek.sc
 EndChar
 
 StartChar: aogonek
@@ -9336,8 +9336,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 579 0 2
 Refer: 26 67 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" cacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" cacute.sc
 EndChar
 
 StartChar: cacute
@@ -9409,8 +9409,8 @@ LayerCount: 2
 Fore
 Refer: 2231 -1 N 1 0 0 1 568 0 2
 Refer: 26 67 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ccaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ccaron.sc
 EndChar
 
 StartChar: ccaron
@@ -9436,8 +9436,8 @@ LayerCount: 2
 Fore
 Refer: 2231 -1 N 1 0 0 1 518 0 2
 Refer: 27 68 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" dcaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" dcaron.sc
 EndChar
 
 StartChar: dcaron
@@ -9458,8 +9458,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 359 208 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" dcroat.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" dcroat.sc
 EndChar
 
 StartChar: dcroat
@@ -9578,8 +9578,8 @@ LayerCount: 2
 Fore
 Refer: 259 74 N 1 0 0 1 367 0 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ij.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ij.sc
 EndChar
 
 StartChar: ij
@@ -9745,8 +9745,8 @@ LayerCount: 2
 Fore
 Refer: 655 700 N 1 0 0 1 351 46 2
 Refer: 261 76 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" lcaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" lcaron.sc
 EndChar
 
 StartChar: lcaron
@@ -9816,8 +9816,8 @@ SplineSet
  254 61 268 42 289 42 c 2
  349 42 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" lslash.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" lslash.sc
 EndChar
 
 StartChar: lslash
@@ -9861,8 +9861,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 569 0 2
 Refer: 263 78 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" nacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" nacute.sc
 EndChar
 
 StartChar: nacute
@@ -9905,8 +9905,8 @@ LayerCount: 2
 Fore
 Refer: 2231 -1 N 1 0 0 1 538 0 2
 Refer: 263 78 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ncaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ncaron.sc
 EndChar
 
 StartChar: ncaron
@@ -9977,10 +9977,10 @@ SplineSet
  681 543 703 462 703 329 c 2
  703 103 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
-Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eng.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eng.sc
+Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 Comment: "Sieht in Times anders aus"
 EndChar
 
@@ -10092,8 +10092,8 @@ LayerCount: 2
 Fore
 Refer: 2233 -1 N 1 0 0 1 604 0 2
 Refer: 264 79 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ohungarumlaut.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ohungarumlaut.sc
 EndChar
 
 StartChar: ohungarumlaut
@@ -10208,8 +10208,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 539 0 2
 Refer: 267 82 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" racute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" racute.sc
 EndChar
 
 StartChar: racute
@@ -10252,8 +10252,8 @@ LayerCount: 2
 Fore
 Refer: 2231 -1 N 1 0 0 1 508 0 2
 Refer: 267 82 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" rcaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" rcaron.sc
 EndChar
 
 StartChar: rcaron
@@ -10275,8 +10275,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 449 0 2
 Refer: 268 83 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" sacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" sacute.sc
 EndChar
 
 StartChar: sacute
@@ -10350,8 +10350,8 @@ SplineSet
  254 -186 274 -172 274 -145 c 0
  274 -107.4 221 -103 185 -101 c 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" scedilla.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" scedilla.sc
 EndChar
 
 StartChar: scedilla
@@ -10403,8 +10403,8 @@ LayerCount: 2
 Fore
 Refer: 2231 -1 N 1 0 0 1 429 0 2
 Refer: 268 83 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" scaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" scaron.sc
 EndChar
 
 StartChar: scaron
@@ -10463,8 +10463,8 @@ SplineSet
  349 -186 369 -172 369 -145 c 0
  369 -107.4 316 -103 280 -101 c 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uni021B.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uni021B.sc
 EndChar
 
 StartChar: uni0163
@@ -10521,8 +10521,8 @@ LayerCount: 2
 Fore
 Refer: 2231 -1 N 1 0 0 1 512 0 2
 Refer: 269 84 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" tcaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" tcaron.sc
 EndChar
 
 StartChar: tcaron
@@ -10576,8 +10576,8 @@ SplineSet
  467.1 316.5 436.6 317.5 405 318.2 c 1
  405 123 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" tbar.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" tbar.sc
 EndChar
 
 StartChar: tbar
@@ -10702,8 +10702,8 @@ LayerCount: 2
 Fore
 Refer: 1413 778 N 1 0 0 1 571 70 2
 Refer: 270 85 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uring.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uring.sc
 EndChar
 
 StartChar: uring
@@ -10725,8 +10725,8 @@ LayerCount: 2
 Fore
 Refer: 2233 -1 N 1 0 0 1 665 0 2
 Refer: 270 85 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uhungarumlaut.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uhungarumlaut.sc
 EndChar
 
 StartChar: uhungarumlaut
@@ -10881,8 +10881,8 @@ LayerCount: 2
 Fore
 Refer: 319 168 N 1 0 0 1 145 176 2
 Refer: 274 89 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ydieresis.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ydieresis.sc
 EndChar
 
 StartChar: Zacute
@@ -10893,8 +10893,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 529 0 2
 Refer: 275 90 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" zacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" zacute.sc
 EndChar
 
 StartChar: zacute
@@ -10938,8 +10938,8 @@ LayerCount: 2
 Fore
 Refer: 2231 -1 N 1 0 0 1 492 0 2
 Refer: 275 90 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" zcaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" zcaron.sc
 EndChar
 
 StartChar: zcaron
@@ -12635,8 +12635,8 @@ LayerCount: 2
 Fore
 Refer: 2229 -1 N 1 0 0 1 775 0 2
 Refer: 110 1236 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 EndChar
 
 StartChar: aeacute
@@ -20964,8 +20964,8 @@ SplineSet
  52 232 l 1
  123 282 194 347 296 457 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guilsinglleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guilsinglleft.sc
+Substitution2: "'case' Versalformen 1" guilsinglleft.sc
 EndChar
 
 StartChar: guilsinglright
@@ -20984,8 +20984,8 @@ SplineSet
  304 198 l 1
  233 148 162 83 60 -27 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guilsinglright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guilsinglright.sc
+Substitution2: "'case' Versalformen 1" guilsinglright.sc
 EndChar
 
 StartChar: exclamdbl
@@ -22468,9 +22468,9 @@ SplineSet
 EndSplineSet
 Refer: 336 185 N 1 0 0 1 -14 -49 2
 Refer: 330 179 N 1 0 0 1 358 -497 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction three
 Ligature2: "'frac' Brueche 1" one slash three
-LCarets2: 2 0 0
 EndChar
 
 StartChar: twothirds
@@ -22488,9 +22488,9 @@ SplineSet
 EndSplineSet
 Refer: 330 179 N 1 0 0 1 352 -499 2
 Refer: 329 178 N 1 0 0 1 0 -101 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" two fraction three
 Ligature2: "'frac' Brueche 1" two slash three
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2155
@@ -22508,9 +22508,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 342 -497 2
 Refer: 336 185 N 1 0 0 1 -7 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction five
 Ligature2: "'frac' Brueche 1" one slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2156
@@ -22528,9 +22528,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 343 -496 2
 Refer: 329 178 N 1 0 0 1 1 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" two fraction five
 Ligature2: "'frac' Brueche 1" two slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2157
@@ -22548,9 +22548,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 340 -496 2
 Refer: 330 179 N 1 0 0 1 -1 -103 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three fraction five
 Ligature2: "'frac' Brueche 1" three slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2158
@@ -22568,9 +22568,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 344 -496 2
 Refer: 1073 8308 N 1 0 0 1 -9 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" four fraction five
 Ligature2: "'frac' Brueche 1" four slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: oneeighth
@@ -22588,9 +22588,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 348 -499 2
 Refer: 336 185 N 1 0 0 1 -7 -49 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction eight
 Ligature2: "'frac' Brueche 1" one slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: threeeighths
@@ -22608,9 +22608,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 347 -497 2
 Refer: 330 179 N 1 0 0 1 2 -104 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three fraction eight
 Ligature2: "'frac' Brueche 1" three slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: fiveeighths
@@ -22628,9 +22628,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 342 -498 2
 Refer: 1074 8309 N 1 0 0 1 -4 -48 2
-Ligature2: "'frac' Brueche 1" three fraction eight
-Ligature2: "'frac' Brueche 1" five slash eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five slash eight
+Ligature2: "'frac' Brueche 1" three fraction eight
 EndChar
 
 StartChar: seveneighths
@@ -22648,9 +22648,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 352 -497 2
 Refer: 1076 8311 N 1 0 0 1 1 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" seven fraction eight
 Ligature2: "'frac' Brueche 1" seven slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni215F
@@ -30497,8 +30497,8 @@ SplineSet
  417 426 l 2
  417 432 435 434 455 434 c 0
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" s t
 LCarets2: 1 411
+Ligature2: "'hlig' Historische Ligaturen 1" s t
 EndChar
 
 StartChar: uni02B0
@@ -33858,9 +33858,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8310 N 1 0 0 1 346 -498 2
 Refer: 336 185 N 1 0 0 1 -2 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction six
 Ligature2: "'frac' Brueche 1" one slash six
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni215A
@@ -33878,9 +33878,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8310 N 1 0 0 1 345 -497 2
 Refer: 1074 8309 N 1 0 0 1 -1 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" five fraction six
 Ligature2: "'frac' Brueche 1" five slash six
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni221B
@@ -40890,8 +40890,8 @@ LayerCount: 2
 Fore
 Refer: 257 48 N 1 0 0 1 9 0 2
 Substitution2: "'case' Versalformen Figures" zero.cap.fitted
-Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 Substitution2: "'tnum' Tabellenziffern 1" zero
+Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 EndChar
 
 StartChar: semicolon
@@ -45065,8 +45065,8 @@ SplineSet
  84 35 100 44 100 127 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" l.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E1
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" l.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E1
 EndChar
 
 StartChar: s
@@ -45103,8 +45103,8 @@ SplineSet
  56.5 49.5 52 96.5 48 146 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" s.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" s.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E2
 EndChar
 
 StartChar: x
@@ -45158,8 +45158,8 @@ SplineSet
  183 73 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2093
-Substitution2: "'sups' Hochgestellte 1" uni02E3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" x.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E3
 EndChar
 
 StartChar: uni03D8
@@ -51209,8 +51209,8 @@ SplineSet
  101 35 117 44 117 127 c 2
  117 333 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle.sc
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 EndChar
 
 StartChar: ohungarumlaut.sc
@@ -51496,8 +51496,8 @@ SplineSet
  157 58 199 30 252 30 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" eight.cap
-Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'onum' Minuskelziffern 1" eight.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
 Substitution2: "'sups' Hochgestellte 1" uni2078
 EndChar
@@ -51596,8 +51596,8 @@ SplineSet
  5 4 5 26 15 32 c 1
  70 35 98 39 98 123 c 2
 EndSplineSet
-Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 EndChar
 
 StartChar: uni2201
@@ -52107,8 +52107,8 @@ SplineSet
  564 367 l 1
  564 523 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" h.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" h.sc
 EndChar
 
 StartChar: germandbls.sc
@@ -52292,8 +52292,8 @@ SplineSet
  37 319.1 103.2 403.4 189.9 432.7 c 1
  160.6 446.1 149 462.3 149 479 c 0
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" c t
 LCarets2: 1 422
+Ligature2: "'hlig' Historische Ligaturen 1" c t
 EndChar
 
 StartChar: uni27E6
@@ -52362,8 +52362,8 @@ SplineSet
  125 -10 39 52 39 221 c 0
  39 371 129 444 257 444 c 0
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 Substitution2: "'lnum' Versalziffern 1" zero
+Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 EndChar
 
 StartChar: one.taboldstyle
@@ -52373,8 +52373,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 1374 -1 N 1 0 0 1 34 0 2
-Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 Substitution2: "'lnum' Versalziffern 1" one
+Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 EndChar
 
 StartChar: two.taboldstyle
@@ -52384,8 +52384,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 1460 -1 N 1 0 0 1 7 0 2
-Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 Substitution2: "'lnum' Versalziffern 1" two
+Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 EndChar
 
 StartChar: three.taboldstyle
@@ -52395,8 +52395,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 12 51 N 1 0 0 1 -11 -166 2
-Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 Substitution2: "'lnum' Versalziffern 1" three
+Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 EndChar
 
 StartChar: four.taboldstyle
@@ -52406,8 +52406,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 13 52 N 1 0 0 1 1 -162 2
-Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 Substitution2: "'lnum' Versalziffern 1" four
+Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 EndChar
 
 StartChar: five.taboldstyle
@@ -52417,8 +52417,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 14 53 N 1 0 0 1 -17 -166 2
-Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 Substitution2: "'lnum' Versalziffern 1" five
+Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 EndChar
 
 StartChar: six.taboldstyle
@@ -52428,8 +52428,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 15 54 N 1 0 0 1 -10 0 2
-Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 Substitution2: "'lnum' Versalziffern 1" six
+Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 EndChar
 
 StartChar: seven.taboldstyle
@@ -52439,8 +52439,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 16 55 N 1 0 0 1 -5 -166 2
-Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 Substitution2: "'lnum' Versalziffern 1" seven
+Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 EndChar
 
 StartChar: nine.taboldstyle
@@ -52450,8 +52450,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 17 57 N 1 0 0 1 -2 -168 2
-Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 Substitution2: "'lnum' Versalziffern 1" nine
+Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 EndChar
 
 StartChar: uni26A5
@@ -52915,9 +52915,9 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 2126 56 N 1 0 0 1 0 0 2
-Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 EndChar
 
 StartChar: zero.slash

--- a/sources/LibertinusSerif-BoldItalic.sfd
+++ b/sources/LibertinusSerif-BoldItalic.sfd
@@ -504,8 +504,8 @@ SplineSet
  215.8 -213 l 1
  44.1 -17 87.2 208 96.8 253 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenleft.sc
+Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208D
 Substitution2: "'sups' Hochgestellte 1" uni207D
 EndChar
@@ -525,8 +525,8 @@ SplineSet
  206.2 717 l 1
  377.9 521 334.8 296 325.2 251 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenright.sc
+Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208E
 Substitution2: "'sups' Hochgestellte 1" uni207E
 EndChar
@@ -626,8 +626,8 @@ SplineSet
  376.4 122 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" one.cap
-Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'onum' Minuskelziffern 1" one.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
 Substitution2: "'sups' Hochgestellte 1" uni00B9
 EndChar
@@ -662,8 +662,8 @@ SplineSet
  139.6 512 195.2 553.6 257 583.1 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" two.cap
-Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'onum' Minuskelziffern 1" two.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
 Substitution2: "'sups' Hochgestellte 1" uni00B2
 EndChar
@@ -702,8 +702,8 @@ SplineSet
  397 520 363.5 550 324.9 550 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" three.cap
-Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'onum' Minuskelziffern 1" three.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
 Substitution2: "'sups' Hochgestellte 1" uni00B3
 EndChar
@@ -742,8 +742,8 @@ SplineSet
  502.4 209 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" four.cap
-Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'onum' Minuskelziffern 1" four.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
 Substitution2: "'sups' Hochgestellte 1" uni2074
 EndChar
@@ -780,8 +780,8 @@ SplineSet
  339.5 97 357.8 133.5 357.8 193.1 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" five.cap
-Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'onum' Minuskelziffern 1" five.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
 Substitution2: "'sups' Hochgestellte 1" uni2075
 EndChar
@@ -813,8 +813,8 @@ SplineSet
  538.5 628 541.5 616 541.5 601.5 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" six.cap
-Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'onum' Minuskelziffern 1" six.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
 Substitution2: "'sups' Hochgestellte 1" uni2076
 EndChar
@@ -841,8 +841,8 @@ SplineSet
  261 498 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" seven.cap
-Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'onum' Minuskelziffern 1" seven.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
 Substitution2: "'sups' Hochgestellte 1" uni2077
 EndChar
@@ -874,8 +874,8 @@ SplineSet
  79.7 -28 76.7 -16 76.7 -1.5 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" nine.cap
-Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'onum' Minuskelziffern 1" nine.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
 Substitution2: "'sups' Hochgestellte 1" uni2079
 EndChar
@@ -4234,8 +4234,8 @@ SplineSet
  366 294 374 284 374 273 c 0
  374 260 350 215 327 215 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" hyphen.cap
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" hyphen.sc
+Substitution2: "'case' Versalformen 1" hyphen.cap
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 EndChar
 
@@ -4277,11 +4277,11 @@ SplineSet
  375.2 16 306.7 -10 253.3 -10 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" zero.cap
-Substitution2: "'zero' gestrichene Null 1" zero.slash
-Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
 Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'zero' gestrichene Null 1" zero.slash
 EndChar
 
 StartChar: H
@@ -4441,8 +4441,8 @@ SplineSet
  211 523 l 2
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
-Substitution2: "'ss02' Stilgruppe 2 1" K.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" k.sc
+Substitution2: "'ss02' Stilgruppe 2 1" K.alt
 EndChar
 
 StartChar: L
@@ -4712,8 +4712,8 @@ SplineSet
  193 647 421 654 459 654 c 0
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
-Substitution2: "'ss02' Stilgruppe 2 1" R.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" r.sc
+Substitution2: "'ss02' Stilgruppe 2 1" R.alt
 EndChar
 
 StartChar: S
@@ -5063,8 +5063,8 @@ SplineSet
  287.9 -169 284.1 -187 276.8 -193 c 1
  31.8 -193 l 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" bracketleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" bracketleft.sc
+Substitution2: "'case' Versalformen 1" bracketleft.sc
 EndChar
 
 StartChar: backslash
@@ -5099,8 +5099,8 @@ SplineSet
  217.1 679 220.9 697 228.2 703 c 1
  473.2 703 l 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" bracketright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" bracketright.sc
+Substitution2: "'case' Versalformen 1" bracketright.sc
 EndChar
 
 StartChar: asciicircum
@@ -5177,8 +5177,8 @@ SplineSet
  276.1 84.5 315.5 136 364.5 226 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2090
-Substitution2: "'sups' Hochgestellte 1" a.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" a.sc
+Substitution2: "'sups' Hochgestellte 1" a.superior
 EndChar
 
 StartChar: b
@@ -5211,8 +5211,8 @@ SplineSet
  279.2 335.6 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" b.inferior
-Substitution2: "'sups' Hochgestellte 1" b.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" b.sc
+Substitution2: "'sups' Hochgestellte 1" b.superior
 EndChar
 
 StartChar: c
@@ -5237,8 +5237,8 @@ SplineSet
  409 118 421 96 421 87 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" c.inferior
-Substitution2: "'sups' Hochgestellte 1" c.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" c.sc
+Substitution2: "'sups' Hochgestellte 1" c.superior
 EndChar
 
 StartChar: d
@@ -5286,8 +5286,8 @@ SplineSet
  360 219.6 370.3 243.6 377.2 264.1 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" d.inferior
-Substitution2: "'sups' Hochgestellte 1" d.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" d.sc
+Substitution2: "'sups' Hochgestellte 1" d.superior
 EndChar
 
 StartChar: e
@@ -5317,8 +5317,8 @@ SplineSet
  390.6 255 319.2 226.1 193 199 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2091
-Substitution2: "'sups' Hochgestellte 1" e.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" e.sc
+Substitution2: "'sups' Hochgestellte 1" e.superior
 EndChar
 
 StartChar: f
@@ -5362,8 +5362,8 @@ SplineSet
  160 216 169 268.5 191 382 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" f.inferior
-Substitution2: "'sups' Hochgestellte 1" f.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" f.sc
+Substitution2: "'sups' Hochgestellte 1" f.superior
 EndChar
 
 StartChar: g
@@ -5410,8 +5410,8 @@ SplineSet
  338 172 331 229 331 291 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" g.inferior
-Substitution2: "'sups' Hochgestellte 1" g.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" g.sc
+Substitution2: "'sups' Hochgestellte 1" g.superior
 EndChar
 
 StartChar: h
@@ -5453,8 +5453,8 @@ SplineSet
  225.9 72 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B0
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" h.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B0
 EndChar
 
 StartChar: i
@@ -5468,11 +5468,11 @@ LayerCount: 2
 Fore
 Refer: 459 775 N 1 0 0 1 304 0 2
 Refer: 361 305 N 1 0 0 1 0 0 2
-Substitution2: "Substitution dotless forms 1" dotlessi
 Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
-Substitution2: "'sups' Hochgestellte 1" uni2071
-Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > i.sc 1" i.sc
+Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
+Substitution2: "'sups' Hochgestellte 1" uni2071
+Substitution2: "Substitution dotless forms 1" dotlessi
 EndChar
 
 StartChar: j
@@ -5483,10 +5483,10 @@ LayerCount: 2
 Fore
 Refer: 459 775 N 1 0 0 1 309 0 2
 Refer: 934 567 N 1 0 0 1 0 0 2
-Substitution2: "Substitution dotless forms 1" uni0237
 Substitution2: "'sinf' Wissenschaftliche Indices 1" j.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" j.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B2
+Substitution2: "Substitution dotless forms 1" uni0237
 EndChar
 
 StartChar: k
@@ -5533,8 +5533,8 @@ SplineSet
  220.9 72 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" k.inferior
-Substitution2: "'sups' Hochgestellte 1" k.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" k.sc
+Substitution2: "'sups' Hochgestellte 1" k.superior
 EndChar
 
 StartChar: l
@@ -5563,8 +5563,8 @@ SplineSet
  208 563 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" l.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E1
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" l.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E1
 EndChar
 
 StartChar: m
@@ -5618,8 +5618,8 @@ SplineSet
  146 243 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" m.inferior
-Substitution2: "'sups' Hochgestellte 1" m.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" m.sc
+Substitution2: "'sups' Hochgestellte 1" m.superior
 EndChar
 
 StartChar: n
@@ -5662,8 +5662,8 @@ SplineSet
  140 243 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" n.inferior
-Substitution2: "'sups' Hochgestellte 1" uni207F
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" n.sc
+Substitution2: "'sups' Hochgestellte 1" uni207F
 EndChar
 
 StartChar: o
@@ -5692,8 +5692,8 @@ SplineSet
  93 -10 67 98 67 162 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2092
-Substitution2: "'sups' Hochgestellte 1" o.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" o.sc
+Substitution2: "'sups' Hochgestellte 1" o.superior
 EndChar
 
 StartChar: p
@@ -5740,8 +5740,8 @@ SplineSet
  402 32 447 207 447 273 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" p.inferior
-Substitution2: "'sups' Hochgestellte 1" p.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" p.sc
+Substitution2: "'sups' Hochgestellte 1" p.superior
 EndChar
 
 StartChar: q
@@ -5785,8 +5785,8 @@ SplineSet
  277.3 -200.9 291 -188.8 298 -161 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" q.inferior
-Substitution2: "'sups' Hochgestellte 1" q.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" q.sc
+Substitution2: "'sups' Hochgestellte 1" q.superior
 EndChar
 
 StartChar: r
@@ -5821,8 +5821,8 @@ SplineSet
  346.4 351.4 318 315 270 228 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" r.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" r.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B3
 EndChar
 
 StartChar: s
@@ -5856,8 +5856,8 @@ SplineSet
  359 439 421 404 426 355 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" s.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" s.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E2
 EndChar
 
 StartChar: t
@@ -5895,8 +5895,8 @@ SplineSet
  108.3 67.7 112.8 95.4 118 118 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" t.inferior
-Substitution2: "'sups' Hochgestellte 1" t.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" t.sc
+Substitution2: "'sups' Hochgestellte 1" t.superior
 EndChar
 
 StartChar: u
@@ -5941,8 +5941,8 @@ SplineSet
  422.7 64.4 427.4 85.7 431 106.7 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" u.inferior
-Substitution2: "'sups' Hochgestellte 1" u.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" u.sc
+Substitution2: "'sups' Hochgestellte 1" u.superior
 EndChar
 
 StartChar: v
@@ -5975,8 +5975,8 @@ SplineSet
  331.5 107.5 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" v.inferior
-Substitution2: "'sups' Hochgestellte 1" v.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" v.sc
+Substitution2: "'sups' Hochgestellte 1" v.superior
 EndChar
 
 StartChar: w
@@ -6017,8 +6017,8 @@ SplineSet
  441.2 217.7 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" w.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B7
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" w.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B7
 EndChar
 
 StartChar: x
@@ -6060,8 +6060,8 @@ SplineSet
  235.5 248.8 196.5 333.5 196.5 333.5 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2093
-Substitution2: "'sups' Hochgestellte 1" uni02E3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" x.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E3
 EndChar
 
 StartChar: y
@@ -6097,8 +6097,8 @@ SplineSet
  276 -32 225.3 290 191 338 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" y.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B8
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" y.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B8
 EndChar
 
 StartChar: z
@@ -6132,8 +6132,8 @@ SplineSet
  417.8 415.5 425.9 417 457.6 450 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" z.inferior
-Substitution2: "'sups' Hochgestellte 1" z.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" z.sc
+Substitution2: "'sups' Hochgestellte 1" z.superior
 EndChar
 
 StartChar: braceleft
@@ -6161,8 +6161,8 @@ SplineSet
  434.8 701 432.2 689 425.3 683 c 1
  387.2 672 339.4 654.9 322.2 552 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" braceleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" braceleft.sc
+Substitution2: "'case' Versalformen 1" braceleft.sc
 EndChar
 
 StartChar: bar
@@ -6205,8 +6205,8 @@ SplineSet
  -22.8 -205 -20.2 -193 -13.3 -187 c 1
  24.8 -176 72.6 -158.9 89.8 -56 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" braceright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" braceright.sc
+Substitution2: "'case' Versalformen 1" braceright.sc
 EndChar
 
 StartChar: asciitilde
@@ -6258,8 +6258,8 @@ SplineSet
  138 412 172 444 212 444 c 0
  252 444 284 414 284 376 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" exclamdown.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" exclamdown.sc
+Substitution2: "'case' Versalformen 1" exclamdown.sc
 EndChar
 
 StartChar: cent
@@ -6602,8 +6602,8 @@ SplineSet
  473 35 457.5 26 447.9 23 c 1
  399 106.7 364.8 145.9 314 207 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guillemotleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guillemotleft.sc
+Substitution2: "'case' Versalformen 1" guillemotleft.sc
 EndChar
 
 StartChar: logicalnot
@@ -6984,8 +6984,8 @@ SplineSet
  171 395 186.5 404 196.1 407 c 1
  245 323.3 279.2 284.1 330 223 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guillemotright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guillemotright.sc
+Substitution2: "'case' Versalformen 1" guillemotright.sc
 EndChar
 
 StartChar: onequarter
@@ -7117,8 +7117,8 @@ SplineSet
  261.8 408 300.5 440 338.1 440 c 0
  375.7 440 399.4 410 391.3 372 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" questiondown.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" questiondown.sc
+Substitution2: "'case' Versalformen 1" questiondown.sc
 EndChar
 
 StartChar: Agrave
@@ -8897,8 +8897,8 @@ SplineSet
 EndSplineSet
 Refer: 459 775 N 1 0 0 1 602 0 2
 Refer: 459 775 N 1 0 0 1 337 0 2
-Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" ij.sc
 LCarets2: 1 255
+Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" ij.sc
 EndChar
 
 StartChar: Jcircumflex
@@ -9347,10 +9347,10 @@ SplineSet
  799 437 794 388 781 329 c 2
  733 103 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
-Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=1
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eng.sc
+Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 EndChar
 
 StartChar: eng
@@ -18811,8 +18811,8 @@ SplineSet
  114 235 l 1
  194 284 280 349 371 430 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guilsinglleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guilsinglleft.sc
+Substitution2: "'case' Versalformen 1" guilsinglleft.sc
 EndChar
 
 StartChar: guilsinglright
@@ -18831,8 +18831,8 @@ SplineSet
  326 195 l 1
  245 146 159 81 68 0 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guilsinglright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guilsinglright.sc
+Substitution2: "'case' Versalformen 1" guilsinglright.sc
 EndChar
 
 StartChar: exclamdbl
@@ -20569,9 +20569,9 @@ LayerCount: 2
 Fore
 Refer: 800 8543 N 1 0 0 1 0 0 2
 Refer: 754 8323 N 1 0 0 1 388 33 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction three
 Ligature2: "'frac' Brueche 1" one slash three
-LCarets2: 2 0 0
 EndChar
 
 StartChar: twothirds
@@ -20589,9 +20589,9 @@ SplineSet
 EndSplineSet
 Refer: 754 8323 N 1 0 0 1 352 31 2
 Refer: 753 8322 N 1 0 0 1 99 428 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" two fraction three
 Ligature2: "'frac' Brueche 1" two slash three
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2155
@@ -20602,9 +20602,9 @@ LayerCount: 2
 Fore
 Refer: 800 8543 N 1 0 0 1 0 0 2
 Refer: 740 8309 N 1 0 0 1 252 -497 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction five
 Ligature2: "'frac' Brueche 1" one slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2156
@@ -20622,9 +20622,9 @@ SplineSet
 EndSplineSet
 Refer: 753 8322 N 1 0 0 1 121 481 2
 Refer: 740 8309 N 1 0 0 1 243 -496 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" two fraction five
 Ligature2: "'frac' Brueche 1" two slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2157
@@ -20658,9 +20658,9 @@ SplineSet
  511.1 -107 527.9 -72.4 537.3 -28.1 c 0
 EndSplineSet
 Refer: 754 8323 N 1 0 0 1 99 427 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three fraction five
 Ligature2: "'frac' Brueche 1" three slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2158
@@ -20678,9 +20678,9 @@ SplineSet
 EndSplineSet
 Refer: 740 8309 N 1 0 0 1 244 -496 2
 Refer: 739 8308 N 1 0 0 1 1 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" four fraction five
 Ligature2: "'frac' Brueche 1" four slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: oneeighth
@@ -20691,9 +20691,9 @@ LayerCount: 2
 Fore
 Refer: 800 8543 N 1 0 0 1 0 0 2
 Refer: 743 8312 N 1 0 0 1 248 -499 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction eight
 Ligature2: "'frac' Brueche 1" one slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: threeeighths
@@ -20711,9 +20711,9 @@ SplineSet
 EndSplineSet
 Refer: 754 8323 N 1 0 0 1 92 426 2
 Refer: 743 8312 N 1 0 0 1 247 -497 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three fraction eight
 Ligature2: "'frac' Brueche 1" three slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: fiveeighths
@@ -20731,9 +20731,9 @@ SplineSet
 EndSplineSet
 Refer: 743 8312 N 1 0 0 1 242 -498 2
 Refer: 740 8309 N 1 0 0 1 -4 -48 2
-Ligature2: "'frac' Brueche 1" three fraction eight
-Ligature2: "'frac' Brueche 1" five slash eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five slash eight
+Ligature2: "'frac' Brueche 1" three fraction eight
 EndChar
 
 StartChar: seveneighths
@@ -20751,9 +20751,9 @@ SplineSet
 EndSplineSet
 Refer: 743 8312 N 1 0 0 1 252 -497 2
 Refer: 742 8311 N 1 0 0 1 31 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" seven fraction eight
 Ligature2: "'frac' Brueche 1" seven slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni215F
@@ -34246,8 +34246,8 @@ LayerCount: 2
 Fore
 Refer: 198 48 N 1 0 0 1 6 0 2
 Substitution2: "'case' Versalformen Figures" zero.cap.fitted
-Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 Substitution2: "'tnum' Tabellenziffern 1" zero
+Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 EndChar
 
 StartChar: one.fitted
@@ -34479,9 +34479,9 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 1410 56 N 1 0 0 1 0 0 2
-Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 EndChar
 
 StartChar: nine.oldstyle
@@ -41756,8 +41756,8 @@ SplineSet
  188.1 65 221.7 32 261.9 32 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" eight.cap
-Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'onum' Minuskelziffern 1" eight.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
 Substitution2: "'sups' Hochgestellte 1" uni2078
 EndChar
@@ -42037,8 +42037,8 @@ SplineSet
  103 35 120 44 137 127 c 2
  179 333 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle.sc
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 EndChar
 
 StartChar: ohungarumlaut.sc
@@ -43045,8 +43045,8 @@ SplineSet
  86.1 245 126.8 332.5 177.4 380 c 0
  223.1 422.9 282.6 444 348.8 444 c 0
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 Substitution2: "'lnum' Versalziffern 1" zero
+Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 EndChar
 
 StartChar: one.taboldstyle
@@ -43056,8 +43056,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 953 -1 N 1 0 0 1 44 0 2
-Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 Substitution2: "'lnum' Versalziffern 1" one
+Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 EndChar
 
 StartChar: two.taboldstyle
@@ -43067,8 +43067,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 1409 -1 N 1 0 0 1 27 0 2
-Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 Substitution2: "'lnum' Versalziffern 1" two
+Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 EndChar
 
 StartChar: three.taboldstyle
@@ -43078,8 +43078,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 954 -1 N 1 0 0 1 -3 0 2
-Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 Substitution2: "'lnum' Versalziffern 1" three
+Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 EndChar
 
 StartChar: four.taboldstyle
@@ -43089,8 +43089,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 13 52 N 1 0 0 1 -29 -162 2
-Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 Substitution2: "'lnum' Versalziffern 1" four
+Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 EndChar
 
 StartChar: five.taboldstyle
@@ -43100,8 +43100,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 14 53 N 1 0 0 1 -47 -166 2
-Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 Substitution2: "'lnum' Versalziffern 1" five
+Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 EndChar
 
 StartChar: six.taboldstyle
@@ -43111,8 +43111,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 960 -1 N 1 0 0 1 2 0 2
-Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 Substitution2: "'lnum' Versalziffern 1" six
+Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 EndChar
 
 StartChar: seven.taboldstyle
@@ -43122,8 +43122,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 16 55 N 1 0 0 1 -35 -166 2
-Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 Substitution2: "'lnum' Versalziffern 1" seven
+Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 EndChar
 
 StartChar: eight.taboldstyle
@@ -43143,8 +43143,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 17 57 N 1 0 0 1 -17.2 -168 2
-Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 Substitution2: "'lnum' Versalziffern 1" nine
+Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 EndChar
 
 StartChar: uni2098

--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -552,8 +552,8 @@ SplineSet
  226 -204 l 1
  169 -145 130 -80 108 0 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenleft.sc
+Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208D
 Substitution2: "'sups' Hochgestellte 1" uni207D
 EndChar
@@ -579,8 +579,8 @@ SplineSet
  194 708 l 1
  251 649 290 583 312 504 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenright.sc
+Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208E
 Substitution2: "'sups' Hochgestellte 1" uni207E
 EndChar
@@ -689,8 +689,8 @@ SplineSet
  308 76 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" one.cap
-Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'onum' Minuskelziffern 1" one.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
 Substitution2: "'sups' Hochgestellte 1" uni00B9
 EndChar
@@ -728,8 +728,8 @@ SplineSet
  151.704101562 506.831054688 185.946289062 558.2890625 244 587.21875 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" two.cap
-Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'onum' Minuskelziffern 1" two.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
 Substitution2: "'sups' Hochgestellte 1" uni00B2
 EndChar
@@ -767,8 +767,8 @@ SplineSet
  405 552 372 579 333 579 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" three.cap
-Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'onum' Minuskelziffern 1" three.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
 Substitution2: "'sups' Hochgestellte 1" uni00B3
 EndChar
@@ -809,8 +809,8 @@ SplineSet
  468.697265625 213 l 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" four.cap
-Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'onum' Minuskelziffern 1" four.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
 Substitution2: "'sups' Hochgestellte 1" uni2074
 EndChar
@@ -845,8 +845,8 @@ SplineSet
  338.950195312 95.75390625 367 150.701171875 367 216 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" five.cap
-Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'onum' Minuskelziffern 1" five.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
 Substitution2: "'sups' Hochgestellte 1" uni2075
 EndChar
@@ -878,8 +878,8 @@ SplineSet
  256 323 224 314 175 278 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" six.cap
-Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'onum' Minuskelziffern 1" six.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
 Substitution2: "'sups' Hochgestellte 1" uni2076
 EndChar
@@ -907,8 +907,8 @@ SplineSet
  272 544 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" seven.cap
-Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'onum' Minuskelziffern 1" seven.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
 Substitution2: "'sups' Hochgestellte 1" uni2077
 EndChar
@@ -940,8 +940,8 @@ SplineSet
  326.393554688 276 358.393554688 285 407.393554688 321 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" nine.cap
-Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'onum' Minuskelziffern 1" nine.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
 Substitution2: "'sups' Hochgestellte 1" uni2079
 EndChar
@@ -5535,8 +5535,8 @@ SplineSet
  318 25 358 64 419 132 c 1
  376 207 317 319 311 340 c 1
 EndSplineSet
-Substitution2: "'salt' Stilistische Alternativformen 1" ampersand.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ampersand.alt
+Substitution2: "'salt' Stilistische Alternativformen 1" ampersand.alt
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" ampersand.alt
 EndChar
 
@@ -5590,8 +5590,8 @@ SplineSet
  346 283 349 278 349 271 c 0
  349 255.7 329.1 223 314 223 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" hyphen.cap
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" hyphen.sc
+Substitution2: "'case' Versalformen 1" hyphen.cap
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 EndChar
 
@@ -5634,11 +5634,11 @@ SplineSet
  376 572 362 578 345 578 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" zero.cap
-Substitution2: "'zero' gestrichene Null 1" zero.slash
-Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
 Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'zero' gestrichene Null 1" zero.slash
 EndChar
 
 StartChar: H
@@ -5771,9 +5771,9 @@ SplineSet
  480 677 496 670 496 649 c 0
  496 625 462 598 435 580 c 1
 EndSplineSet
-Substitution2: "'salt' Stilistische Alternativformen 1" J.alt
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" j.sc
+Substitution2: "'salt' Stilistische Alternativformen 1" J.alt
 EndChar
 
 StartChar: K
@@ -5840,8 +5840,8 @@ SplineSet
  213 569 l 2
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
-Substitution2: "'ss02' Stilgruppe 2 1" K.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" k.sc
+Substitution2: "'ss02' Stilgruppe 2 1" K.alt
 EndChar
 
 StartChar: L
@@ -6184,8 +6184,8 @@ SplineSet
  303 645 363 654 387 654 c 0
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
-Substitution2: "'ss02' Stilgruppe 2 1" R.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" r.sc
+Substitution2: "'ss02' Stilgruppe 2 1" R.alt
 EndChar
 
 StartChar: S
@@ -6588,8 +6588,8 @@ SplineSet
  209 689 l 1
  424 689 l 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" bracketleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" bracketleft.sc
+Substitution2: "'case' Versalformen 1" bracketleft.sc
 EndChar
 
 StartChar: backslash
@@ -6624,8 +6624,8 @@ SplineSet
  211 -200 l 1
  -3 -200 l 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" bracketright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" bracketright.sc
+Substitution2: "'case' Versalformen 1" bracketright.sc
 EndChar
 
 StartChar: asciicircum
@@ -6696,8 +6696,8 @@ SplineSet
  234 45 311 129 360 219 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2090
-Substitution2: "'sups' Hochgestellte 1" a.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" a.sc
+Substitution2: "'sups' Hochgestellte 1" a.superior
 EndChar
 
 StartChar: b
@@ -6733,8 +6733,8 @@ SplineSet
  285.3 25 410 156 410 301 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" b.inferior
-Substitution2: "'sups' Hochgestellte 1" b.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" b.sc
+Substitution2: "'sups' Hochgestellte 1" b.superior
 EndChar
 
 StartChar: c
@@ -6767,8 +6767,8 @@ SplineSet
  346 41.5 281 -10 209 -10 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" c.inferior
-Substitution2: "'sups' Hochgestellte 1" c.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" c.sc
+Substitution2: "'sups' Hochgestellte 1" c.superior
 EndChar
 
 StartChar: d
@@ -6814,8 +6814,8 @@ SplineSet
  345 116 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" d.inferior
-Substitution2: "'sups' Hochgestellte 1" d.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" d.sc
+Substitution2: "'sups' Hochgestellte 1" d.superior
 EndChar
 
 StartChar: e
@@ -6844,8 +6844,8 @@ SplineSet
  424 327 428 250 167 199 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2091
-Substitution2: "'sups' Hochgestellte 1" e.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" e.sc
+Substitution2: "'sups' Hochgestellte 1" e.superior
 EndChar
 
 StartChar: f
@@ -6890,8 +6890,8 @@ SplineSet
  157 216 168 276 188 390 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" f.inferior
-Substitution2: "'sups' Hochgestellte 1" f.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" f.sc
+Substitution2: "'sups' Hochgestellte 1" f.superior
 EndChar
 
 StartChar: g
@@ -6937,8 +6937,8 @@ SplineSet
  328 162 341 229 341 291 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" g.inferior
-Substitution2: "'sups' Hochgestellte 1" g.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" g.sc
+Substitution2: "'sups' Hochgestellte 1" g.superior
 EndChar
 
 StartChar: h
@@ -6985,8 +6985,8 @@ SplineSet
 EndSplineSet
 Substitution2: "'salt' Stilistische Alternativformen 1" h.alt
 Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B0
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" h.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B0
 EndChar
 
 StartChar: i
@@ -7000,11 +7000,11 @@ LayerCount: 2
 Fore
 Refer: 675 775 N 1 0 0 1 304 -34 2
 Refer: 421 305 N 1 0 0 1 0 0 2
-Substitution2: "Substitution dotless forms 1" dotlessi
 Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
-Substitution2: "'sups' Hochgestellte 1" uni2071
-Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > i.sc 1" i.sc
+Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
+Substitution2: "'sups' Hochgestellte 1" uni2071
+Substitution2: "Substitution dotless forms 1" dotlessi
 EndChar
 
 StartChar: j
@@ -7015,10 +7015,10 @@ LayerCount: 2
 Fore
 Refer: 675 775 N 1 0 0 1 309 -34 2
 Refer: 1721 567 N 1 0 0 1 0 0 2
-Substitution2: "Substitution dotless forms 1" uni0237
 Substitution2: "'sinf' Wissenschaftliche Indices 1" j.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" j.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B2
+Substitution2: "Substitution dotless forms 1" uni0237
 EndChar
 
 StartChar: k
@@ -7067,8 +7067,8 @@ SplineSet
  76.1 27 84 52 88.8 72 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" k.inferior
-Substitution2: "'sups' Hochgestellte 1" k.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" k.sc
+Substitution2: "'sups' Hochgestellte 1" k.superior
 EndChar
 
 StartChar: l
@@ -7100,8 +7100,8 @@ SplineSet
  311 688 300.5 647.9 286 583 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" l.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E1
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" l.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E1
 EndChar
 
 StartChar: m
@@ -7157,8 +7157,8 @@ SplineSet
  182 321 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" m.inferior
-Substitution2: "'sups' Hochgestellte 1" m.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" m.sc
+Substitution2: "'sups' Hochgestellte 1" m.superior
 EndChar
 
 StartChar: n
@@ -7203,8 +7203,8 @@ SplineSet
  433 124 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" n.inferior
-Substitution2: "'sups' Hochgestellte 1" uni207F
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" n.sc
+Substitution2: "'sups' Hochgestellte 1" uni207F
 EndChar
 
 StartChar: o
@@ -7234,8 +7234,8 @@ SplineSet
  91 -10 78 109 78 162 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2092
-Substitution2: "'sups' Hochgestellte 1" o.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" o.sc
+Substitution2: "'sups' Hochgestellte 1" o.superior
 EndChar
 
 StartChar: p
@@ -7283,8 +7283,8 @@ SplineSet
  407 155.2 427 224.5 427 273 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" p.inferior
-Substitution2: "'sups' Hochgestellte 1" p.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" p.sc
+Substitution2: "'sups' Hochgestellte 1" p.superior
 EndChar
 
 StartChar: q
@@ -7328,8 +7328,8 @@ SplineSet
  274.3 -200.9 288 -188.8 295 -161 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" q.inferior
-Substitution2: "'sups' Hochgestellte 1" q.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" q.sc
+Substitution2: "'sups' Hochgestellte 1" q.superior
 EndChar
 
 StartChar: r
@@ -7365,8 +7365,8 @@ SplineSet
  221 285 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" r.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" r.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B3
 EndChar
 
 StartChar: s
@@ -7400,8 +7400,8 @@ SplineSet
  184 -10 179 -10 174 -10 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" s.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" s.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E2
 EndChar
 
 StartChar: t
@@ -7439,8 +7439,8 @@ SplineSet
  186 429 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" t.inferior
-Substitution2: "'sups' Hochgestellte 1" t.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" t.sc
+Substitution2: "'sups' Hochgestellte 1" t.superior
 EndChar
 
 StartChar: u
@@ -7486,8 +7486,8 @@ SplineSet
  519 400 509.6 369.9 506 352 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" u.inferior
-Substitution2: "'sups' Hochgestellte 1" u.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" u.sc
+Substitution2: "'sups' Hochgestellte 1" u.superior
 EndChar
 
 StartChar: v
@@ -7519,8 +7519,8 @@ SplineSet
  304.6 76 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" v.inferior
-Substitution2: "'sups' Hochgestellte 1" v.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" v.sc
+Substitution2: "'sups' Hochgestellte 1" v.superior
 EndChar
 
 StartChar: w
@@ -7565,8 +7565,8 @@ SplineSet
  290.9 2.3 272.7 -12 265 -12 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" w.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B7
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" w.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B7
 EndChar
 
 StartChar: x
@@ -7613,8 +7613,8 @@ SplineSet
  215 309 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2093
-Substitution2: "'sups' Hochgestellte 1" uni02E3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" x.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E3
 EndChar
 
 StartChar: y
@@ -7653,8 +7653,8 @@ SplineSet
  494.1 218.9 372.1 32.4 352.5 0 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" y.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B8
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" y.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B8
 EndChar
 
 StartChar: z
@@ -7692,8 +7692,8 @@ SplineSet
  400 412 415 418 438 444 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" z.inferior
-Substitution2: "'sups' Hochgestellte 1" z.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" z.sc
+Substitution2: "'sups' Hochgestellte 1" z.superior
 EndChar
 
 StartChar: braceleft
@@ -7728,8 +7728,8 @@ SplineSet
  346 691 327 678 311 656 c 0
  297 638 287 608 279 567 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" braceleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" braceleft.sc
+Substitution2: "'case' Versalformen 1" braceleft.sc
 EndChar
 
 StartChar: bar
@@ -7779,8 +7779,8 @@ SplineSet
  15 -197 34 -184 50 -162 c 0
  63 -144 74 -114 82 -73 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" braceright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" braceright.sc
+Substitution2: "'case' Versalformen 1" braceright.sc
 EndChar
 
 StartChar: asciitilde
@@ -7838,8 +7838,8 @@ SplineSet
  149 -102 148 -125 143 -158 c 1
  133 -212 98 -231 75 -231 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" exclamdown.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" exclamdown.sc
+Substitution2: "'case' Versalformen 1" exclamdown.sc
 EndChar
 
 StartChar: cent
@@ -8195,8 +8195,8 @@ SplineSet
  502 383 l 1
  433 304 387 256 336 215 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guillemotleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guillemotleft.sc
+Substitution2: "'case' Versalformen 1" guillemotleft.sc
 EndChar
 
 StartChar: logicalnot
@@ -8632,8 +8632,8 @@ SplineSet
  61 47 l 1
  130 126 176 174 227 215 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guillemotright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guillemotright.sc
+Substitution2: "'case' Versalformen 1" guillemotright.sc
 EndChar
 
 StartChar: onequarter
@@ -8730,8 +8730,8 @@ SplineSet
  97 -148 128 -193 178 -193 c 0
  235 -193 280 -166 285 -136 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" questiondown.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" questiondown.sc
+Substitution2: "'case' Versalformen 1" questiondown.sc
 EndChar
 
 StartChar: Agrave
@@ -9456,8 +9456,8 @@ SplineSet
  326 666 296 550 272 442 c 2
  257 374 l 2
 EndSplineSet
-Substitution2: "'ss03' Stilgruppe 3 1" germandbls.ss03
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" germandbls.ss03
 EndChar
 
 StartChar: agrave
@@ -10340,8 +10340,8 @@ SplineSet
 EndSplineSet
 Refer: 675 775 N 1 0 0 1 559 -34 2
 Refer: 675 775 N 1 0 0 1 308 -34 2
-Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" ij.sc
 LCarets2: 1 255
+Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" ij.sc
 EndChar
 
 StartChar: Jcircumflex
@@ -10769,10 +10769,10 @@ SplineSet
  95 34 110 48 116 76 c 2
  213 569 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eng.sc
 Substitution2: "'locl' Localized Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 EndChar
 
 StartChar: eng
@@ -13806,8 +13806,8 @@ LayerCount: 2
 Fore
 Refer: 2213 -1 N 1 0 0 1 775 128 2
 Refer: 351 198 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 EndChar
 
 StartChar: aeacute
@@ -26034,8 +26034,8 @@ SplineSet
  114 235 l 1
  194 284 280 349 371 430 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guilsinglleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guilsinglleft.sc
+Substitution2: "'case' Versalformen 1" guilsinglleft.sc
 EndChar
 
 StartChar: guilsinglright
@@ -26054,8 +26054,8 @@ SplineSet
  326 195 l 1
  245 146 159 81 68 0 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guilsinglright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guilsinglright.sc
+Substitution2: "'case' Versalformen 1" guilsinglright.sc
 EndChar
 
 StartChar: exclamdbl
@@ -27822,9 +27822,9 @@ LayerCount: 2
 Fore
 Refer: 1135 8543 N 1 0 0 1 0 0 2
 Refer: 1089 8323 N 1 0 0 1 358 33 2
+LCarets2: 2 248 427
 Ligature2: "'frac' Brueche 1" one fraction three
 Ligature2: "'frac' Brueche 1" one slash three
-LCarets2: 2 248 427
 EndChar
 
 StartChar: twothirds
@@ -27842,9 +27842,9 @@ SplineSet
 EndSplineSet
 Refer: 1089 8323 N 1 0 0 1 352 31 2
 Refer: 1088 8322 N 1 0 0 1 99 428 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" two fraction three
 Ligature2: "'frac' Brueche 1" two slash three
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2155
@@ -27855,9 +27855,9 @@ LayerCount: 2
 Fore
 Refer: 1135 8543 N 1 0 0 1 0 0 2
 Refer: 1075 8309 N 1 0 0 1 271 -445 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction five
 Ligature2: "'frac' Brueche 1" one slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2156
@@ -27875,9 +27875,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8309 N 1 0 0 1 262 -444 2
 Refer: 331 178 N 1 0 0 1 1 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" two fraction five
 Ligature2: "'frac' Brueche 1" two slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2157
@@ -27895,9 +27895,9 @@ SplineSet
 EndSplineSet
 Refer: 1089 8323 N 1 0 0 1 99 427 2
 Refer: 1075 8309 N 1 0 0 1 267 -444 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three fraction five
 Ligature2: "'frac' Brueche 1" three slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2158
@@ -27915,9 +27915,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8309 N 1 0 0 1 263 -444 2
 Refer: 1074 8308 N 1 0 0 1 1 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" four fraction five
 Ligature2: "'frac' Brueche 1" four slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: oneeighth
@@ -27928,9 +27928,9 @@ LayerCount: 2
 Fore
 Refer: 1135 8543 N 1 0 0 1 0 0 2
 Refer: 1078 8312 N 1 0 0 1 258 -446 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction eight
 Ligature2: "'frac' Brueche 1" one slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: threeeighths
@@ -27948,9 +27948,9 @@ SplineSet
 EndSplineSet
 Refer: 1089 8323 N 1 0 0 1 112 426 2
 Refer: 1078 8312 N 1 0 0 1 257 -444 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three fraction eight
 Ligature2: "'frac' Brueche 1" three slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: fiveeighths
@@ -27968,9 +27968,9 @@ SplineSet
 EndSplineSet
 Refer: 1078 8312 N 1 0 0 1 252 -445 2
 Refer: 1075 8309 N 1 0 0 1 -4 -48 2
-Ligature2: "'frac' Brueche 1" three fraction eight
-Ligature2: "'frac' Brueche 1" five slash eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five slash eight
+Ligature2: "'frac' Brueche 1" three fraction eight
 EndChar
 
 StartChar: seveneighths
@@ -27988,9 +27988,9 @@ SplineSet
 EndSplineSet
 Refer: 1078 8312 N 1 0 0 1 262 -444 2
 Refer: 1077 8311 N 1 0 0 1 31 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" seven fraction eight
 Ligature2: "'frac' Brueche 1" seven slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni215F
@@ -39272,8 +39272,8 @@ SplineSet
  448 417 455 425 474 426 c 2
  527 429 l 1
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" s t
 LCarets2: 1 354
+Ligature2: "'hlig' Historische Ligaturen 1" s t
 EndChar
 
 StartChar: uniE008
@@ -45228,8 +45228,8 @@ LayerCount: 2
 Fore
 Refer: 258 48 N 1 0 0 1 14 0 2
 Substitution2: "'case' Versalformen Figures" zero.cap.fitted
-Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 Substitution2: "'tnum' Tabellenziffern 1" zero
+Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 EndChar
 
 StartChar: one.fitted
@@ -45469,9 +45469,9 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 2066 56 N 1 0 0 1 -9 0 2
-Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 EndChar
 
 StartChar: nine.oldstyle
@@ -62663,8 +62663,8 @@ SplineSet
  423 533 389 582 335 582 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" eight.cap
-Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'onum' Minuskelziffern 1" eight.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
 Substitution2: "'sups' Hochgestellte 1" uni2078
 EndChar
@@ -62989,8 +62989,8 @@ SplineSet
  249 460 274 462 274 462 c 1
  188 65 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 Substitution2: "'locl' Localized Forms for Sami-1" Eng.UCStyle.sc
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 EndChar
 
 StartChar: ohungarumlaut.sc
@@ -64395,8 +64395,8 @@ SplineSet
  110 -10 44 72 73 219 c 0
  98 350 200 439 305 439 c 0
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 Substitution2: "'lnum' Versalziffern 1" zero
+Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 EndChar
 
 StartChar: one.taboldstyle
@@ -64422,8 +64422,8 @@ SplineSet
  105 4 109 25 116 31 c 1
  184 34 211 39 227 122 c 2
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 Substitution2: "'lnum' Versalziffern 1" one
+Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 EndChar
 
 StartChar: two.taboldstyle
@@ -64433,8 +64433,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 2065 -1 N 1 0 0 1 -1 0 2
-Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 Substitution2: "'lnum' Versalziffern 1" two
+Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 EndChar
 
 StartChar: three.taboldstyle
@@ -64444,8 +64444,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 12 51 N 1 0 0 1 -40 -171 2
-Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 Substitution2: "'lnum' Versalziffern 1" three
+Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 EndChar
 
 StartChar: four.taboldstyle
@@ -64455,8 +64455,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 13 52 N 1 0 0 1 -52.0003 -172 2
-Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 Substitution2: "'lnum' Versalziffern 1" four
+Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 EndChar
 
 StartChar: five.taboldstyle
@@ -64466,8 +64466,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 14 53 N 1 0 0 1 -40 -172 2
-Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 Substitution2: "'lnum' Versalziffern 1" five
+Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 EndChar
 
 StartChar: six.taboldstyle
@@ -64477,8 +64477,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 15 54 N 1 0 0 1 -8 0.0201103 2
-Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 Substitution2: "'lnum' Versalziffern 1" six
+Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 EndChar
 
 StartChar: seven.taboldstyle
@@ -64488,8 +64488,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 16 55 N 1 0 0 1 -52 -171 2
-Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 Substitution2: "'lnum' Versalziffern 1" seven
+Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 EndChar
 
 StartChar: eight.taboldstyle
@@ -64509,8 +64509,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 17 57 N 1 0 0 1 -48.9997 -171 2
-Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 Substitution2: "'lnum' Versalziffern 1" nine
+Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 EndChar
 
 StartChar: uni2098
@@ -65076,8 +65076,8 @@ SplineSet
  57 28 l 2
  98 28 114 44 119 71 c 2
 EndSplineSet
-Substitution2: "'ss03' Stilgruppe 3 1" uni1E9C.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" uni1E9C.alt
 EndChar
 
 StartChar: germandbls.ss03

--- a/sources/LibertinusSerif-Regular.sfd
+++ b/sources/LibertinusSerif-Regular.sfd
@@ -555,9 +555,9 @@ SplineSet
  48 -24 44 207 44 252 c 0
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenleft.sc
+Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208D
 Substitution2: "'sups' Hochgestellte 1" uni207D
-Substitution2: "'case' Versalformen 1" parenleft.sc
 EndChar
 
 StartChar: parenright
@@ -576,9 +576,9 @@ SplineSet
  250 528 254 297 254 252 c 0
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenright.sc
+Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208E
 Substitution2: "'sups' Hochgestellte 1" uni207E
-Substitution2: "'case' Versalformen 1" parenright.sc
 Colour: ff00ff
 EndChar
 
@@ -653,8 +653,8 @@ SplineSet
  252 646 l 1
  293 646 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" fraction
 Ligature2: "'frac' Brueche 1" uni2215
+Substitution2: "'sups' Hochgestellte 1" fraction
 EndChar
 
 StartChar: one
@@ -681,10 +681,10 @@ SplineSet
  288 122 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" one.cap
-Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'onum' Minuskelziffern 1" one.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni00B9
+Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
+Substitution2: "'sups' Hochgestellte 1" uni00B9
 EndChar
 
 StartChar: two
@@ -718,10 +718,10 @@ SplineSet
  80 429 61 447 61 468 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" two.cap
-Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'onum' Minuskelziffern 1" two.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni00B2
+Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
+Substitution2: "'sups' Hochgestellte 1" uni00B2
 EndChar
 
 StartChar: three
@@ -754,10 +754,10 @@ SplineSet
  298.1 549 258.2 575 215 575 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" three.cap
-Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'onum' Minuskelziffern 1" three.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni00B3
+Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
+Substitution2: "'sups' Hochgestellte 1" uni00B3
 EndChar
 
 StartChar: four
@@ -794,10 +794,10 @@ SplineSet
  430 219 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" four.cap
-Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'onum' Minuskelziffern 1" four.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2074
+Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
+Substitution2: "'sups' Hochgestellte 1" uni2074
 EndChar
 
 StartChar: five
@@ -828,10 +828,10 @@ SplineSet
  269 24 319 94 319 189 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" five.cap
-Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'onum' Minuskelziffern 1" five.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2075
+Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
+Substitution2: "'sups' Hochgestellte 1" uni2075
 EndChar
 
 StartChar: six
@@ -858,10 +858,10 @@ SplineSet
  235 535.2 171.4 434.2 144.3 343.3 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" six.cap
-Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'onum' Minuskelziffern 1" six.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2076
+Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
+Substitution2: "'sups' Hochgestellte 1" uni2076
 EndChar
 
 StartChar: seven
@@ -887,10 +887,10 @@ SplineSet
  170 535 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" seven.cap
-Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'onum' Minuskelziffern 1" seven.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2077
+Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
+Substitution2: "'sups' Hochgestellte 1" uni2077
 EndChar
 
 StartChar: nine
@@ -917,10 +917,10 @@ SplineSet
  236 63.8 299.6 164.8 326.7 255.7 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" nine.cap
-Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'onum' Minuskelziffern 1" nine.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2079
+Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
+Substitution2: "'sups' Hochgestellte 1" uni2079
 Colour: ff00ff
 EndChar
 
@@ -2090,8 +2090,8 @@ LayerCount: 2
 Fore
 Refer: 1682 856 N 1 0 0 1 163 113 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 Colour: ff00ff
 EndChar
 
@@ -5167,10 +5167,10 @@ SplineSet
  300 614 251 585 251 519 c 0
  251 496 263 458 289 409 c 1
 EndSplineSet
-Substitution2: "'ss06' Stilgruppe 6-1" ampersand.alt
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ampersand.alt
 Substitution2: "'salt' Stilistische Alternativformen 1" ampersand.alt
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" ampersand.alt
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ampersand.alt
+Substitution2: "'ss06' Stilgruppe 6-1" ampersand.alt
 EndChar
 
 StartChar: quotesingle
@@ -5222,11 +5222,11 @@ SplineSet
  294 283 298 273 298 263 c 0
  298 251 284 223 271 223 c 2
 EndSplineSet
-Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208B
-Substitution2: "'sups' Hochgestellte 1" uni207B
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" hyphen.sc
-Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 Substitution2: "'case' Versalformen 1" hyphen.cap
+Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208B
+Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
+Substitution2: "'sups' Hochgestellte 1" uni207B
 EndChar
 
 StartChar: period
@@ -5266,13 +5266,13 @@ SplineSet
  398 487 422 402 422 303 c 0
  422 68 305 -10 228 -10 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen Figures" zero.cap
-Substitution2: "'zero' gestrichene Null 1" zero.slash
-Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
-Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
 Substitution2: "'case' Versalformen 1" zero.cap
-Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'case' Versalformen Figures" zero.cap
+Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
+Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'zero' gestrichene Null 1" zero.slash
 EndChar
 
 StartChar: I
@@ -5332,10 +5332,10 @@ SplineSet
  309 641 309 620 303 614 c 1
  243 611 226 606 226 523 c 2
 EndSplineSet
-Substitution2: "'salt' Stilistische Alternativformen 1" J.alt
-Substitution2: "'ss02' Stilgruppe 2 1" J.alt
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" j.sc
+Substitution2: "'salt' Stilistische Alternativformen 1" J.alt
+Substitution2: "'ss02' Stilgruppe 2 1" J.alt
 EndChar
 
 StartChar: K
@@ -5387,8 +5387,8 @@ SplineSet
  191 122 l 2
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
-Substitution2: "'ss02' Stilgruppe 2 1" K.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" k.sc
+Substitution2: "'ss02' Stilgruppe 2 1" K.alt
 Colour: ff9ccc
 EndChar
 
@@ -5673,8 +5673,8 @@ SplineSet
  189 122 l 2
 EndSplineSet
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
-Substitution2: "'ss02' Stilgruppe 2 1" R.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" r.sc
+Substitution2: "'ss02' Stilgruppe 2 1" R.alt
 EndChar
 
 StartChar: S
@@ -5878,9 +5878,9 @@ SplineSet
  653.7 130.7 l 1
  810 565 l 2
 EndSplineSet
-Substitution2: "'ss05' Stilgruppe 5" W.alt
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" w.sc
+Substitution2: "'ss05' Stilgruppe 5" W.alt
 EndChar
 
 StartChar: X
@@ -6149,9 +6149,9 @@ SplineSet
  434.3 7 398.3 -10 360 -10 c 0
  309.6 -10 299 17 293 48 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni1D43
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2090
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" a.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D43
 EndChar
 
 StartChar: b
@@ -6190,8 +6190,8 @@ SplineSet
  157 390 160.7 388.3 167 394 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" b.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D47
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" b.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D47
 EndChar
 
 StartChar: c
@@ -6220,8 +6220,8 @@ SplineSet
  386 104 394 100 398 91 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" c.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D9C
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" c.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D9C
 EndChar
 
 StartChar: d
@@ -6268,8 +6268,8 @@ SplineSet
  348.3 56 338.8 54.2 334 50.3 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" d.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D48
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" d.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D48
 EndChar
 
 StartChar: e
@@ -6303,9 +6303,9 @@ SplineSet
  184 60 226 39 262 39 c 0
  320 39 349 55 386 93 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni1D49
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2091
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" e.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D49
 EndChar
 
 StartChar: f
@@ -6348,8 +6348,8 @@ SplineSet
  175 122 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" f.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1DA0
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" f.sc
+Substitution2: "'sups' Hochgestellte 1" uni1DA0
 EndChar
 
 StartChar: g
@@ -6402,8 +6402,8 @@ SplineSet
  481 405 463 387 444 387 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" g.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D4D
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" g.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D4D
 EndChar
 
 StartChar: h
@@ -6450,10 +6450,10 @@ SplineSet
  272.6 387 222 365.3 184 328 c 0
  176 319.3 167 307 167 285.9 c 2
 EndSplineSet
-Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
 Substitution2: "'salt' Stilistische Alternativformen 1" h.alt
-Substitution2: "'sups' Hochgestellte 1" uni02B0
+Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" h.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B0
 EndChar
 
 StartChar: i
@@ -6469,11 +6469,11 @@ LayerCount: 2
 Fore
 Refer: 673 775 N 1 0 0 1 320 23 2
 Refer: 419 305 N 1 0 0 1 0 0 2
-Substitution2: "Substitution dotless forms 1" dotlessi
+Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > i.sc 1" i.sc
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
-Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
 Substitution2: "'sups' Hochgestellte 1" uni2071
+Substitution2: "Substitution dotless forms 1" dotlessi
 Colour: ff00ff
 EndChar
 
@@ -6487,10 +6487,10 @@ LayerCount: 2
 Fore
 Refer: 673 775 N 1 0 0 1 329 23 2
 Refer: 1721 567 N 1 0 0 1 0 0 2
-Substitution2: "Substitution dotless forms 1" uni0237
 Substitution2: "'sinf' Wissenschaftliche Indices 1" j.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" j.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B2
+Substitution2: "Substitution dotless forms 1" uni0237
 Colour: ff00ff
 EndChar
 
@@ -6543,8 +6543,8 @@ SplineSet
  75 35 86 39 86 122 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" k.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D4F
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" k.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D4F
 EndChar
 
 StartChar: uni02E1
@@ -6627,8 +6627,8 @@ SplineSet
  166.7 423.7 168.7 387.7 170 358 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" m.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D50
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" m.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D50
 EndChar
 
 StartChar: n
@@ -6674,8 +6674,8 @@ SplineSet
  172.3 348.6 177.9 351 184 358 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" n.inferior
-Substitution2: "'sups' Hochgestellte 1" uni207F
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" n.sc
+Substitution2: "'sups' Hochgestellte 1" uni207F
 EndChar
 
 StartChar: o
@@ -6704,9 +6704,9 @@ SplineSet
  312 25 377 56 377 182 c 0
  377 326 324 404 238 404 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni1D52
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2092
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" o.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D52
 EndChar
 
 StartChar: p
@@ -6751,8 +6751,8 @@ SplineSet
  152.7 423.7 154.5 398 156 368 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" p.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D56
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" p.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D56
 EndChar
 
 StartChar: q
@@ -6793,8 +6793,8 @@ SplineSet
  335 -198 346 -194 346 -111 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" q.inferior
-Substitution2: "'sups' Hochgestellte 1" q.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" q.sc
+Substitution2: "'sups' Hochgestellte 1" q.superior
 EndChar
 
 StartChar: r
@@ -6833,8 +6833,8 @@ SplineSet
  172.7 423.7 174.3 398 176 358 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" r.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" r.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B3
 EndChar
 
 StartChar: uni02E2
@@ -6907,8 +6907,8 @@ SplineSet
  25 417 29 429 43 429 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" t.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D57
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" t.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D57
 EndChar
 
 StartChar: u
@@ -6953,8 +6953,8 @@ SplineSet
  303 10 256 -10 217 -10 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" u.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D58
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" u.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D58
 EndChar
 
 StartChar: v
@@ -6990,8 +6990,8 @@ SplineSet
  384.6 381.8 379 394 325 398 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" v.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1D5B
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" v.sc
+Substitution2: "'sups' Hochgestellte 1" uni1D5B
 EndChar
 
 StartChar: w
@@ -7040,8 +7040,8 @@ SplineSet
  209 425 209 404 203 398 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" w.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B7
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" w.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B7
 EndChar
 
 StartChar: uni02E3
@@ -7126,8 +7126,8 @@ SplineSet
  232.7 -103.6 219.6 -132.2 204 -160 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" y.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B8
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" y.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B8
 EndChar
 
 StartChar: z
@@ -7165,8 +7165,8 @@ SplineSet
  65 435.4 68.6 439 71 439 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" z.inferior
-Substitution2: "'sups' Hochgestellte 1" uni1DBB
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" z.sc
+Substitution2: "'sups' Hochgestellte 1" uni1DBB
 EndChar
 
 StartChar: braceleft
@@ -7993,8 +7993,8 @@ SplineSet
 EndSplineSet
 Refer: 1073 8308 N 1 0 0 1 348 -446 2
 Refer: 336 185 N 1 0 0 1 -3 -49 2
-Ligature2: "'frac' Brueche 1" one slash four
 LCarets2: 2 215 424
+Ligature2: "'frac' Brueche 1" one slash four
 Colour: ff9ccc
 EndChar
 
@@ -8806,8 +8806,8 @@ SplineSet
  17 4 17 25 23 31 c 1
  80 34 92 39 92 122 c 2
 EndSplineSet
-Substitution2: "'ss03' Stilgruppe 3 1" germandbls.ss03
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" germandbls.ss03
 EndChar
 
 StartChar: agrave
@@ -10112,10 +10112,10 @@ SplineSet
  69 646 98 645 148 645 c 0
  161 645 173 646 182 647 c 0
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
-Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eng.sc
+Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 Comment: "Sieht in Times anders aus"
 EndChar
 
@@ -12882,8 +12882,8 @@ LayerCount: 2
 Fore
 Refer: 2405 -1 N 1 0 0 1 775 128 2
 Refer: 110 1236 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Colour: ff00ff
 EndChar
 
@@ -14983,9 +14983,9 @@ SplineSet
  -228 693 -205 710 -171 710 c 0
  -166 710 -160 709 -156 708 c 1
 EndSplineSet
+Substitution2: "'case' Versalformen 1" uni0358
 Substitution2: "'sups' Hochgestellte 1" gravecomb.sups
 Substitution2: "Substitution cap-Accents 1" grave.cap
-Substitution2: "'case' Versalformen 1" uni0358
 EndChar
 
 StartChar: acutecomb
@@ -15009,9 +15009,9 @@ SplineSet
  -239 572.2 -235.7 576.2 -227.6 589 c 2
  -152 708 l 1
 EndSplineSet
+Substitution2: "'case' Versalformen 1" uni0359
 Substitution2: "'sups' Hochgestellte 1" acutecomb.sups
 Substitution2: "Substitution cap-Accents 1" acute.cap
-Substitution2: "'case' Versalformen 1" uni0359
 EndChar
 
 StartChar: uni0302
@@ -15033,9 +15033,9 @@ SplineSet
  -230 611 -184 665 -155 711 c 1
  -144.3 713.3 -133.7 714 -123 711 c 1
 EndSplineSet
+Substitution2: "'case' Versalformen 1" uni035A
 Substitution2: "'sups' Hochgestellte 1" uni0302.sups
 Substitution2: "Substitution cap-Accents 1" circumflex.cap
-Substitution2: "'case' Versalformen 1" uni035A
 EndChar
 
 StartChar: tildecomb
@@ -22905,9 +22905,9 @@ SplineSet
 EndSplineSet
 Refer: 336 185 N 1 0 0 1 -14 -49 2
 Refer: 330 179 N 1 0 0 1 358 -443 2
-Ligature2: "'frac' Brueche 1" one slash three
-Ligature2: "'frac' Brueche 1" one fraction three
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction three
+Ligature2: "'frac' Brueche 1" one slash three
 Colour: ff9ccc
 EndChar
 
@@ -22926,9 +22926,9 @@ SplineSet
 EndSplineSet
 Refer: 330 179 N 1 0 0 1 352 -445 2
 Refer: 329 178 N 1 0 0 1 0 -48 2
-Ligature2: "'frac' Brueche 1" two slash three
-Ligature2: "'frac' Brueche 1" two fraction three
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" two fraction three
+Ligature2: "'frac' Brueche 1" two slash three
 Colour: ff9ccc
 EndChar
 
@@ -22947,9 +22947,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 351 -445 2
 Refer: 336 185 N 1 0 0 1 -7 -48 2
-Ligature2: "'frac' Brueche 1" one slash five
-Ligature2: "'frac' Brueche 1" one fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction five
+Ligature2: "'frac' Brueche 1" one slash five
 Colour: ff9ccc
 EndChar
 
@@ -22968,9 +22968,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 352 -444 2
 Refer: 329 178 N 1 0 0 1 1 -48 2
-Ligature2: "'frac' Brueche 1" two slash five
-Ligature2: "'frac' Brueche 1" two fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" two fraction five
+Ligature2: "'frac' Brueche 1" two slash five
 Colour: ff9ccc
 EndChar
 
@@ -22989,9 +22989,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 349 -444 2
 Refer: 330 179 N 1 0 0 1 -1 -49 2
-Ligature2: "'frac' Brueche 1" three slash five
-Ligature2: "'frac' Brueche 1" three fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three fraction five
+Ligature2: "'frac' Brueche 1" three slash five
 Colour: ff9ccc
 EndChar
 
@@ -23010,9 +23010,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 353 -444 2
 Refer: 1073 8308 N 1 0 0 1 -9 -48 2
-Ligature2: "'frac' Brueche 1" four slash five
-Ligature2: "'frac' Brueche 1" four fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" four fraction five
+Ligature2: "'frac' Brueche 1" four slash five
 Colour: ff9ccc
 EndChar
 
@@ -23031,9 +23031,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 348 -446 2
 Refer: 336 185 N 1 0 0 1 -7 -49 2
-Ligature2: "'frac' Brueche 1" one slash eight
-Ligature2: "'frac' Brueche 1" one fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction eight
+Ligature2: "'frac' Brueche 1" one slash eight
 Colour: ff9ccc
 EndChar
 
@@ -23052,9 +23052,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 347 -444 2
 Refer: 330 179 N 1 0 0 1 2 -50 2
-Ligature2: "'frac' Brueche 1" three slash eight
-Ligature2: "'frac' Brueche 1" three fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three fraction eight
+Ligature2: "'frac' Brueche 1" three slash eight
 Colour: ff9ccc
 EndChar
 
@@ -23073,9 +23073,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 342 -445 2
 Refer: 1074 8309 N 1 0 0 1 -4 -48 2
-Ligature2: "'frac' Brueche 1" five slash eight
-Ligature2: "'frac' Brueche 1" five fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five fraction eight
+Ligature2: "'frac' Brueche 1" five slash eight
 Colour: ff9ccc
 EndChar
 
@@ -23094,9 +23094,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 352 -444 2
 Refer: 1076 8311 N 1 0 0 1 1 -48 2
-Ligature2: "'frac' Brueche 1" seven slash eight
-Ligature2: "'frac' Brueche 1" seven fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" seven fraction eight
+Ligature2: "'frac' Brueche 1" seven slash eight
 Colour: ff9ccc
 EndChar
 
@@ -23114,8 +23114,8 @@ SplineSet
  532 601 l 1
 EndSplineSet
 Refer: 336 185 N 1 0 0 1 -10 -48 2
-Ligature2: "'frac' Brueche 1" one slash
 Ligature2: "'frac' Brueche 1" one fraction
+Ligature2: "'frac' Brueche 1" one slash
 Colour: ff9ccc
 EndChar
 
@@ -31264,8 +31264,8 @@ SplineSet
  204.5 439 206.1 439 207.6 439 c 1
  167.8 475 157 511.3 157 558 c 0
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" s t
 LCarets2: 1 357
+Ligature2: "'hlig' Historische Ligaturen 1" s t
 Colour: ff9ccc
 EndChar
 
@@ -32013,8 +32013,8 @@ SplineSet
  -231 529 -282 579 -296 664 c 1
  -269 676 l 1
 EndSplineSet
-Substitution2: "Substitution cap-Accents 1" breve.cap
 Substitution2: "'case' Versalformen 1" uni035C
+Substitution2: "Substitution cap-Accents 1" breve.cap
 EndChar
 
 StartChar: uni0304
@@ -34816,9 +34816,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8310 N 1 0 0 1 345 -445 2
 Refer: 336 185 N 1 0 0 1 -2 -48 2
-Ligature2: "'frac' Brueche 1" one slash six
-Ligature2: "'frac' Brueche 1" one fraction six
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction six
+Ligature2: "'frac' Brueche 1" one slash six
 Colour: ff9ccc
 EndChar
 
@@ -34837,9 +34837,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8310 N 1 0 0 1 344 -444 2
 Refer: 1074 8309 N 1 0 0 1 -1 -48 2
-Ligature2: "'frac' Brueche 1" five slash six
-Ligature2: "'frac' Brueche 1" five fraction six
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five fraction six
+Ligature2: "'frac' Brueche 1" five slash six
 Colour: ff9ccc
 EndChar
 
@@ -44217,8 +44217,8 @@ SplineSet
  405 4 405 25 411 31 c 1
  446 36 458 39 458 122 c 2
 EndSplineSet
-Ligature2: "'dlig' optionale Ligaturen 1" c k
 LCarets2: 1 406
+Ligature2: "'dlig' optionale Ligaturen 1" c k
 EndChar
 
 StartChar: c_h
@@ -44272,8 +44272,8 @@ SplineSet
  619.6 387 581 365.3 543 328 c 0
  535 319.3 526 307 526 285.9 c 2
 EndSplineSet
-Ligature2: "'dlig' optionale Ligaturen 1" c h
 LCarets2: 1 407
+Ligature2: "'dlig' optionale Ligaturen 1" c h
 EndChar
 
 StartChar: uni0360
@@ -44489,8 +44489,8 @@ LayerCount: 2
 Fore
 Refer: 257 48 N 1 0 0 1 15 0 2
 Substitution2: "'case' Versalformen Figures" zero.cap.fitted
-Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 Substitution2: "'tnum' Tabellenziffern 1" zero
+Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 Colour: ff00ff
 EndChar
 
@@ -50474,8 +50474,8 @@ SplineSet
  84 34 95 39 95 122 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" l.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E1
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" l.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E1
 EndChar
 
 StartChar: s
@@ -50512,8 +50512,8 @@ SplineSet
  55 42 52 89 48 138 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" s.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" s.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E2
 EndChar
 
 StartChar: x
@@ -50566,9 +50566,9 @@ SplineSet
  217 425 217 404 211 398 c 1
  166.3 393.3 159.1 391.8 182 358 c 2
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni02E3
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2093
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" x.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E3
 EndChar
 
 StartChar: uni03D8
@@ -56238,8 +56238,8 @@ SplineSet
  439 -96 473 -30 473 96 c 2
  473 235 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle.sc
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 EndChar
 
 StartChar: ohungarumlaut.sc
@@ -56547,10 +56547,10 @@ SplineSet
  113 56 181 25 226 25 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" eight.cap
-Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'onum' Minuskelziffern 1" eight.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
+Substitution2: "'sups' Hochgestellte 1" uni2078
 EndChar
 
 StartChar: uniFFFD
@@ -56647,9 +56647,9 @@ SplineSet
  287 621 189 529 189 320 c 2
  189 122 l 2
 EndSplineSet
-Substitution2: "'ss04' Stilgruppe 4 1" uni1E9E.alt
-Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
+Substitution2: "'ss04' Stilgruppe 4 1" uni1E9E.alt
 EndChar
 
 StartChar: uni2201
@@ -56979,8 +56979,8 @@ LayerCount: 2
 Fore
 Refer: 1861 -1 N 1 0 0 1 -15 0 2
 Substitution2: "'case' Versalformen Figures" zero.slash.cap
-Substitution2: "'sups' Hochgestellte 1" uni2070
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
+Substitution2: "'sups' Hochgestellte 1" uni2070
 EndChar
 
 StartChar: germandbls.sc
@@ -57018,8 +57018,8 @@ SplineSet
  228 437 172 392 172 256 c 2
  172 122 l 2
 EndSplineSet
-Substitution2: "'ss04' Stilgruppe 4 1" germandbls.scalt
 Substitution2: "'ss03' Stilgruppe 3 1" germandbls.scalt
+Substitution2: "'ss04' Stilgruppe 4 1" germandbls.scalt
 EndChar
 
 StartChar: t_z
@@ -57373,9 +57373,9 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 2231 56 N 1 0 0 1 2 0 2
-Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 EndChar
 
 StartChar: nine.oldstyle
@@ -57766,8 +57766,8 @@ SplineSet
  296 33 333 60 364 105 c 1
  382 91 l 1
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" c t
 LCarets2: 1 407
+Ligature2: "'hlig' Historische Ligaturen 1" c t
 EndChar
 
 StartChar: h.alt
@@ -57922,8 +57922,8 @@ SplineSet
  118 -10 32 72 32 219 c 0
  32 350 121 439 230 439 c 0
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 Substitution2: "'lnum' Versalziffern 1" zero
+Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 EndChar
 
 StartChar: one.taboldstyle
@@ -57949,8 +57949,8 @@ SplineSet
  111 4 111 25 117 31 c 1
  187 34 214 39 214 122 c 2
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 Substitution2: "'lnum' Versalziffern 1" one
+Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -57961,8 +57961,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 1462 -1 N 1 0 0 1 -1 0 2
-Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 Substitution2: "'lnum' Versalziffern 1" two
+Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -57973,8 +57973,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 12 51 N 1 0 0 1 2 -171 2
-Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 Substitution2: "'lnum' Versalziffern 1" three
+Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -58011,8 +58011,8 @@ SplineSet
  342 47 l 1
  415 47 l 2
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 Substitution2: "'lnum' Versalziffern 1" four
+Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -58023,8 +58023,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 14 53 N 1 0 0 1 -1 -172 2
-Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 Substitution2: "'lnum' Versalziffern 1" five
+Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -58035,8 +58035,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 15 54 N 1 0 0 1 4 0 2
-Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 Substitution2: "'lnum' Versalziffern 1" six
+Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -58047,8 +58047,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 16 55 N 1 0 0 1 8 -171 2
-Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 Substitution2: "'lnum' Versalziffern 1" seven
+Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -58070,8 +58070,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 17 57 N 1 0 0 1 -11 -171 2
-Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 Substitution2: "'lnum' Versalziffern 1" nine
+Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 Colour: ff00ff
 EndChar
 

--- a/sources/LibertinusSerif-Semibold.sfd
+++ b/sources/LibertinusSerif-Semibold.sfd
@@ -430,8 +430,8 @@ SplineSet
  268 -213 l 1
  41 -17 36 208 36 253 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenleft.sc
+Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208D
 Substitution2: "'sups' Hochgestellte 1" uni207D
 EndChar
@@ -451,8 +451,8 @@ SplineSet
  47 717 l 1
  274 521 279 296 279 251 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenright.sc
+Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208E
 Substitution2: "'sups' Hochgestellte 1" uni207E
 EndChar
@@ -552,8 +552,8 @@ SplineSet
  149 35 207 35 207 81 c 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" one.cap
-Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'onum' Minuskelziffern 1" one.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
 Substitution2: "'sups' Hochgestellte 1" uni00B9
 EndChar
@@ -586,8 +586,8 @@ SplineSet
  73 422 51 441 51 465 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" two.cap
-Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'onum' Minuskelziffern 1" two.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
 Substitution2: "'sups' Hochgestellte 1" uni00B2
 EndChar
@@ -620,8 +620,8 @@ SplineSet
  296 541 263 570 234 570 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" three.cap
-Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'onum' Minuskelziffern 1" three.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
 Substitution2: "'sups' Hochgestellte 1" uni00B3
 EndChar
@@ -660,8 +660,8 @@ SplineSet
  467 219 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" four.cap
-Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'onum' Minuskelziffern 1" four.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
 Substitution2: "'sups' Hochgestellte 1" uni2074
 EndChar
@@ -694,8 +694,8 @@ SplineSet
  259 31 316 89 316 186 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" five.cap
-Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'onum' Minuskelziffern 1" five.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
 Substitution2: "'sups' Hochgestellte 1" uni2075
 EndChar
@@ -725,8 +725,8 @@ SplineSet
  419 579 l 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" six.cap
-Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'onum' Minuskelziffern 1" six.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
 Substitution2: "'sups' Hochgestellte 1" uni2076
 EndChar
@@ -753,8 +753,8 @@ SplineSet
  97 594 121 594 128 594 c 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" seven.cap
-Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'onum' Minuskelziffern 1" seven.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
 Substitution2: "'sups' Hochgestellte 1" uni2077
 EndChar
@@ -784,8 +784,8 @@ SplineSet
  67.5 21 l 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" nine.cap
-Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'onum' Minuskelziffern 1" nine.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
 Substitution2: "'sups' Hochgestellte 1" uni2079
 EndChar
@@ -970,8 +970,8 @@ SplineSet
  216 241 211 240 205 227 c 2
  148 79 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" a.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" a.sc
 EndChar
 
 StartChar: B
@@ -1014,8 +1014,8 @@ SplineSet
  22 1 l 1
  22 21 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" b.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" b.sc
 EndChar
 
 StartChar: C
@@ -1038,8 +1038,8 @@ SplineSet
  631 129 l 1
  563 39 477 -10 371 -10 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" c.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" c.sc
 EndChar
 
 StartChar: D
@@ -1072,8 +1072,8 @@ SplineSet
  681 63 487 0 338 0 c 2
  24 0 l 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" d.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" d.sc
 EndChar
 
 StartChar: E
@@ -1122,8 +1122,8 @@ SplineSet
  532 116 522 54 515 0 c 1
  27 0 l 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" e.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" e.sc
 EndChar
 
 StartChar: F
@@ -1173,8 +1173,8 @@ SplineSet
  223 323 l 1
  223 76 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" f.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" f.sc
 EndChar
 
 StartChar: G
@@ -1212,8 +1212,8 @@ SplineSet
  694 272 l 2
  653 272 649 256 649 229 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" g.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" g.sc
 EndChar
 
 StartChar: grave
@@ -1433,8 +1433,8 @@ LayerCount: 2
 Fore
 Refer: 1733 859 N 1 0 0 1 473 173 2
 Refer: 28 69 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ecaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ecaron.sc
 EndChar
 
 StartChar: ecaron
@@ -1477,8 +1477,8 @@ LayerCount: 2
 Fore
 Refer: 1734 860 N 1 0 0 1 533 149 2
 Refer: 30 71 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" gbreve.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" gbreve.sc
 EndChar
 
 StartChar: gbreve
@@ -1778,8 +1778,8 @@ LayerCount: 2
 Fore
 Refer: 673 775 N 1 0 0 1 326 146 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idotaccent.sc
 EndChar
 
 StartChar: uni0408
@@ -5070,8 +5070,8 @@ SplineSet
  451 207.2 459 205 463 210 c 0
  503 263 542 326 554 355 c 0
 EndSplineSet
-Substitution2: "'salt' Stilistische Alternativformen 1" ampersand.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ampersand.alt
+Substitution2: "'salt' Stilistische Alternativformen 1" ampersand.alt
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" ampersand.alt
 EndChar
 
@@ -5125,8 +5125,8 @@ SplineSet
  312 289 320 279 320 268 c 0
  320 255 298 220 275 220 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" hyphen.cap
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" hyphen.sc
+Substitution2: "'case' Versalformen 1" hyphen.cap
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" hyphen.sc
 EndChar
 
@@ -5167,11 +5167,11 @@ SplineSet
  450 69 326 -10 243 -10 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" zero.cap
-Substitution2: "'zero' gestrichene Null 1" zero.slash
-Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
 Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'zero' gestrichene Null 1" zero.slash
 EndChar
 
 StartChar: I
@@ -5209,8 +5209,8 @@ SplineSet
  235 613 221 597 221 569 c 2
  221 76 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" i.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" i.sc
 EndChar
 
 StartChar: J
@@ -5244,8 +5244,8 @@ SplineSet
  9 -71 24 -89 37 -107 c 0
  47 -120 56 -122 70 -122 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" j.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" j.sc
 EndChar
 
 StartChar: K
@@ -5309,8 +5309,8 @@ SplineSet
  221 294 l 1
  221 76 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" k.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" k.sc
 EndChar
 
 StartChar: L
@@ -5348,8 +5348,8 @@ SplineSet
  94 32 100 41 100 72 c 2
  100 569 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" l.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" l.sc
 EndChar
 
 StartChar: M
@@ -5407,8 +5407,8 @@ SplineSet
  766 613 l 2
  725 613 708.6 597 711 569 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" m.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" m.sc
 EndChar
 
 StartChar: N
@@ -5457,8 +5457,8 @@ SplineSet
  546 168 l 1
  546 569 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" n.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" n.sc
 EndChar
 
 StartChar: O
@@ -5479,8 +5479,8 @@ SplineSet
  37 507 173 658 363 658 c 0
  540 658 694 528 694 329 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" o.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" o.sc
 EndChar
 
 StartChar: P
@@ -5521,8 +5521,8 @@ SplineSet
  44 34 l 2
  84.7 39.8 99 51 99 89 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" p.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" p.sc
 EndChar
 
 StartChar: Q
@@ -5557,8 +5557,8 @@ SplineSet
  139 -153 l 1
  143.8 -144.7 149.8 -137 156.6 -129.9 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" q.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" q.sc
 EndChar
 
 StartChar: R
@@ -5609,8 +5609,8 @@ SplineSet
  45 647 180 654 297 654 c 0
  417 654 532 604 532 482 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" r.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" r.sc
 EndChar
 
 StartChar: S
@@ -5643,8 +5643,8 @@ SplineSet
  42 605 142 658 228 658 c 0
  321 658 327 639 382 631 c 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" s.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" s.sc
 EndChar
 
 StartChar: T
@@ -5689,8 +5689,8 @@ SplineSet
  66 669 l 1
  66 663 66 645 87 645 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" t.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" t.sc
 EndChar
 
 StartChar: U
@@ -5735,8 +5735,8 @@ SplineSet
  502 31 521 170 521 278 c 2
  521 569 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" u.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" u.sc
 EndChar
 
 StartChar: V
@@ -5780,8 +5780,8 @@ SplineSet
  483 562 l 2
  499 604 492 613 427 613 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" v.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" v.sc
 EndChar
 
 StartChar: W
@@ -5851,8 +5851,8 @@ SplineSet
  368 33 l 2
  359 4 337 -12 312 -12 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" w.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" w.sc
 EndChar
 
 StartChar: X
@@ -5920,8 +5920,8 @@ SplineSet
  90 605 52 613 35 613 c 0
  28 613 24 615 24 620 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" x.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" x.sc
 EndChar
 
 StartChar: Y
@@ -5977,8 +5977,8 @@ SplineSet
  200 33 l 2
  241 33 254 44 254 72 c 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" y.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" y.sc
 EndChar
 
 StartChar: Z
@@ -6014,8 +6014,8 @@ SplineSet
  598 165 l 1
  587 113 576 56 572 0 c 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" z.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" z.sc
 EndChar
 
 StartChar: bracketleft
@@ -6035,8 +6035,8 @@ SplineSet
  88 689 l 1
  343 689 l 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" bracketleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" bracketleft.sc
+Substitution2: "'case' Versalformen 1" bracketleft.sc
 EndChar
 
 StartChar: backslash
@@ -6071,8 +6071,8 @@ SplineSet
  246 -200 l 1
  -9 -200 l 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" bracketright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" bracketright.sc
+Substitution2: "'case' Versalformen 1" bracketright.sc
 EndChar
 
 StartChar: uni02C4
@@ -6136,8 +6136,8 @@ SplineSet
  222 45 257 65 282 85 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2090
-Substitution2: "'sups' Hochgestellte 1" a.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" a.sc
+Substitution2: "'sups' Hochgestellte 1" a.superior
 EndChar
 
 StartChar: b
@@ -6172,8 +6172,8 @@ SplineSet
  74 563 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" b.inferior
-Substitution2: "'sups' Hochgestellte 1" b.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" b.sc
+Substitution2: "'sups' Hochgestellte 1" b.superior
 EndChar
 
 StartChar: c
@@ -6197,8 +6197,8 @@ SplineSet
  406 87 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" c.inferior
-Substitution2: "'sups' Hochgestellte 1" c.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" c.sc
+Substitution2: "'sups' Hochgestellte 1" c.superior
 EndChar
 
 StartChar: d
@@ -6236,8 +6236,8 @@ SplineSet
  447 688 444 648 444 583 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" d.inferior
-Substitution2: "'sups' Hochgestellte 1" d.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" d.sc
+Substitution2: "'sups' Hochgestellte 1" d.superior
 EndChar
 
 StartChar: e
@@ -6265,8 +6265,8 @@ SplineSet
  323 46 360 64 397 109 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2091
-Substitution2: "'sups' Hochgestellte 1" e.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" e.sc
+Substitution2: "'sups' Hochgestellte 1" e.superior
 EndChar
 
 StartChar: f
@@ -6311,8 +6311,8 @@ SplineSet
  84 39 99 47 99 75 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" f.inferior
-Substitution2: "'sups' Hochgestellte 1" f.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" f.sc
+Substitution2: "'sups' Hochgestellte 1" f.superior
 EndChar
 
 StartChar: g
@@ -6363,8 +6363,8 @@ SplineSet
  491 399 475 383 447 383 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" g.inferior
-Substitution2: "'sups' Hochgestellte 1" g.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" g.sc
+Substitution2: "'sups' Hochgestellte 1" g.superior
 EndChar
 
 StartChar: h
@@ -6419,8 +6419,8 @@ SplineSet
 EndSplineSet
 Substitution2: "'salt' Stilistische Alternativformen 1" h.alt
 Substitution2: "'sinf' Wissenschaftliche Indices 1" h.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B0
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" h.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B0
 EndChar
 
 StartChar: i
@@ -6443,9 +6443,9 @@ SplineSet
 EndSplineSet
 Refer: 419 305 N 1 0 0 1 0 0 2
 Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
-Substitution2: "'sups' Hochgestellte 1" uni2071
-Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
 Substitution2: "'smcp' Gemeine nach Kapitaelchen i > i.sc 1" i.sc
+Substitution2: "'smcp' Gemeine nach Kapitaelchen i > idotaccent.sc" idotaccent.sc
+Substitution2: "'sups' Hochgestellte 1" uni2071
 EndChar
 
 StartChar: j
@@ -6463,8 +6463,8 @@ SplineSet
 EndSplineSet
 Refer: 1718 567 N 1 0 0 1 0 0 2
 Substitution2: "'sinf' Wissenschaftliche Indices 1" j.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" j.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B2
 EndChar
 
 StartChar: k
@@ -6528,8 +6528,8 @@ SplineSet
  66.6 39.3 83 49 83 77 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" k.inferior
-Substitution2: "'sups' Hochgestellte 1" k.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" k.sc
+Substitution2: "'sups' Hochgestellte 1" k.superior
 EndChar
 
 StartChar: uni02E1
@@ -6629,8 +6629,8 @@ SplineSet
  205 381 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" m.inferior
-Substitution2: "'sups' Hochgestellte 1" m.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" m.sc
+Substitution2: "'sups' Hochgestellte 1" m.superior
 EndChar
 
 StartChar: n
@@ -6686,8 +6686,8 @@ SplineSet
  208 381 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" n.inferior
-Substitution2: "'sups' Hochgestellte 1" uni207F
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" n.sc
+Substitution2: "'sups' Hochgestellte 1" uni207F
 EndChar
 
 StartChar: o
@@ -6709,8 +6709,8 @@ SplineSet
  112 -10 34 104 34 207 c 0
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2092
-Substitution2: "'sups' Hochgestellte 1" o.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" o.sc
+Substitution2: "'sups' Hochgestellte 1" o.superior
 EndChar
 
 StartChar: p
@@ -6755,8 +6755,8 @@ SplineSet
  195 381 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" p.inferior
-Substitution2: "'sups' Hochgestellte 1" p.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" p.sc
+Substitution2: "'sups' Hochgestellte 1" p.superior
 EndChar
 
 StartChar: q
@@ -6796,8 +6796,8 @@ SplineSet
  320.9 -191.4 335 -183 335 -155 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" q.inferior
-Substitution2: "'sups' Hochgestellte 1" q.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" q.sc
+Substitution2: "'sups' Hochgestellte 1" q.superior
 EndChar
 
 StartChar: r
@@ -6837,8 +6837,8 @@ SplineSet
  207 381 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" r.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" r.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B3
 EndChar
 
 StartChar: uni02E2
@@ -6903,8 +6903,8 @@ SplineSet
  199 387 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" t.inferior
-Substitution2: "'sups' Hochgestellte 1" t.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" t.sc
+Substitution2: "'sups' Hochgestellte 1" t.superior
 EndChar
 
 StartChar: u
@@ -6951,8 +6951,8 @@ SplineSet
  462 115 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" u.inferior
-Substitution2: "'sups' Hochgestellte 1" u.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" u.sc
+Substitution2: "'sups' Hochgestellte 1" u.superior
 EndChar
 
 StartChar: v
@@ -6993,8 +6993,8 @@ SplineSet
  474.5 398.5 448 391 433 352 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" v.inferior
-Substitution2: "'sups' Hochgestellte 1" v.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" v.sc
+Substitution2: "'sups' Hochgestellte 1" v.superior
 EndChar
 
 StartChar: w
@@ -7052,8 +7052,8 @@ SplineSet
  186.5 397.5 186 384 195 357 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" w.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B7
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" w.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B7
 EndChar
 
 StartChar: uni02E3
@@ -7147,8 +7147,8 @@ SplineSet
  478 402 449 383 432 341 c 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" y.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02B8
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" y.sc
+Substitution2: "'sups' Hochgestellte 1" uni02B8
 EndChar
 
 StartChar: z
@@ -7180,8 +7180,8 @@ SplineSet
  98 446 l 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" z.inferior
-Substitution2: "'sups' Hochgestellte 1" z.superior
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" z.sc
+Substitution2: "'sups' Hochgestellte 1" z.superior
 EndChar
 
 StartChar: braceleft
@@ -7212,8 +7212,8 @@ SplineSet
  248 688 231 674 218 650 c 0
  210 636 205 607 205 564 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" braceleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" braceleft.sc
+Substitution2: "'case' Versalformen 1" braceleft.sc
 EndChar
 
 StartChar: bar
@@ -7259,8 +7259,8 @@ SplineSet
  58 -192 75 -178 88 -154 c 0
  96 -140 101 -111 101 -68 c 2
 EndSplineSet
-Substitution2: "'case' Versalformen 1" braceright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" braceright.sc
+Substitution2: "'case' Versalformen 1" braceright.sc
 EndChar
 
 StartChar: asciitilde
@@ -7314,8 +7314,8 @@ SplineSet
  51 415 76 440 107 440 c 0
  138 440 163 415 163 385 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" exclamdown.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" exclamdown.sc
+Substitution2: "'case' Versalformen 1" exclamdown.sc
 EndChar
 
 StartChar: cent
@@ -7648,8 +7648,8 @@ SplineSet
  240 232 l 1
  312 282 383 347 485 457 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guillemotleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guillemotleft.sc
+Substitution2: "'case' Versalformen 1" guillemotleft.sc
 EndChar
 
 StartChar: logicalnot
@@ -8011,8 +8011,8 @@ SplineSet
  276 198 l 1
  204 148 133 83 31 -27 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guillemotright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guillemotright.sc
+Substitution2: "'case' Versalformen 1" guillemotright.sc
 EndChar
 
 StartChar: onequarter
@@ -8030,8 +8030,8 @@ SplineSet
 EndSplineSet
 Refer: 1073 8308 N 1 0 0 1 348 -446 2
 Refer: 336 185 N 1 0 0 1 -3 -49 2
-Ligature2: "'frac' Brueche 1" one slash four
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one slash four
 EndChar
 
 StartChar: onehalf
@@ -8049,8 +8049,8 @@ SplineSet
 EndSplineSet
 Refer: 336 185 N 1 0 0 1 -1 -49 2
 Refer: 329 178 N 1 0 0 1 358 -443 2
-Ligature2: "'frac' Brueche 1" one slash two
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one slash two
 EndChar
 
 StartChar: threequarters
@@ -8068,8 +8068,8 @@ SplineSet
 EndSplineSet
 Refer: 1073 8308 N 1 0 0 1 352 -444 2
 Refer: 330 179 N 1 0 0 1 -2 -51 2
-Ligature2: "'frac' Brueche 1" three slash four
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three slash four
 EndChar
 
 StartChar: questiondown
@@ -8102,8 +8102,8 @@ SplineSet
  158 415 183 440 214 440 c 0
  245 440 270 415 270 385 c 0
 EndSplineSet
-Substitution2: "'case' Versalformen 1" questiondown.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" questiondown.sc
+Substitution2: "'case' Versalformen 1" questiondown.sc
 EndChar
 
 StartChar: Agrave
@@ -8114,8 +8114,8 @@ LayerCount: 2
 Fore
 Refer: 1679 856 N 1 0 0 1 501 127 2
 Refer: 24 65 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" agrave.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" agrave.sc
 EndChar
 
 StartChar: Aacute
@@ -8126,8 +8126,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 574 127 2
 Refer: 24 65 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aacute.sc
 EndChar
 
 StartChar: Acircumflex
@@ -8138,8 +8138,8 @@ LayerCount: 2
 Fore
 Refer: 1680 858 N 1 0 0 1 490 166 2
 Refer: 24 65 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" acircumflex.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" acircumflex.sc
 EndChar
 
 StartChar: Atilde
@@ -8150,8 +8150,8 @@ LayerCount: 2
 Fore
 Refer: 672 771 N 1 0 0 1 506 126 2
 Refer: 24 65 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" atilde.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" atilde.sc
 EndChar
 
 StartChar: Adieresis.alt
@@ -8257,8 +8257,8 @@ SplineSet
  879 117 870 55 862 1 c 1
  516 1 l 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ae.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ae.sc
 EndChar
 
 StartChar: Ccedilla
@@ -8282,8 +8282,8 @@ LayerCount: 2
 Fore
 Refer: 1679 856 N 1 0 0 1 462 126 2
 Refer: 28 69 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" egrave.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" egrave.sc
 EndChar
 
 StartChar: Eacute
@@ -8295,8 +8295,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 507 127 2
 Refer: 28 69 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eacute.sc
 EndChar
 
 StartChar: Ecircumflex
@@ -8307,8 +8307,8 @@ LayerCount: 2
 Fore
 Refer: 1680 858 N 1 0 0 1 428 166 2
 Refer: 28 69 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ecircumflex.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ecircumflex.sc
 EndChar
 
 StartChar: Edieresis
@@ -8319,8 +8319,8 @@ LayerCount: 2
 Fore
 Refer: 1798 866 N 1 0 0 1 526 1 2
 Refer: 28 69 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" edieresis.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" edieresis.sc
 EndChar
 
 StartChar: Igrave
@@ -8331,8 +8331,8 @@ LayerCount: 2
 Fore
 Refer: 1679 856 N 1 0 0 1 316 126 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" igrave.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" igrave.sc
 EndChar
 
 StartChar: Iacute
@@ -8343,8 +8343,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 367 126 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" iacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" iacute.sc
 EndChar
 
 StartChar: Icircumflex
@@ -8355,8 +8355,8 @@ LayerCount: 2
 Fore
 Refer: 1680 858 N 1 0 0 1 278 166 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" icircumflex.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" icircumflex.sc
 EndChar
 
 StartChar: Idieresis
@@ -8367,8 +8367,8 @@ LayerCount: 2
 Fore
 Refer: 1798 866 N 1 0 0 1 398 12 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idieresis.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" idieresis.sc
 EndChar
 
 StartChar: Eth
@@ -8398,8 +8398,8 @@ LayerCount: 2
 Fore
 Refer: 672 771 N 1 0 0 1 501 124 2
 Refer: 263 78 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ntilde.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ntilde.sc
 EndChar
 
 StartChar: Ograve
@@ -8410,8 +8410,8 @@ LayerCount: 2
 Fore
 Refer: 1679 856 N 1 0 0 1 521 128 2
 Refer: 264 79 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ograve.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ograve.sc
 EndChar
 
 StartChar: Oacute
@@ -8422,8 +8422,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 544 127 2
 Refer: 264 79 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" oacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" oacute.sc
 EndChar
 
 StartChar: Ocircumflex
@@ -8434,8 +8434,8 @@ LayerCount: 2
 Fore
 Refer: 1680 858 N 1 0 0 1 479 166 2
 Refer: 264 79 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ocircumflex.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ocircumflex.sc
 EndChar
 
 StartChar: Otilde
@@ -8446,8 +8446,8 @@ LayerCount: 2
 Fore
 Refer: 672 771 N 1 0 0 1 494 124 2
 Refer: 264 79 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" otilde.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" otilde.sc
 EndChar
 
 StartChar: Odieresis.alt
@@ -8523,8 +8523,8 @@ LayerCount: 2
 Fore
 Refer: 1679 856 N 1 0 0 1 494 127 2
 Refer: 270 85 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ugrave.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ugrave.sc
 EndChar
 
 StartChar: Uacute
@@ -8535,8 +8535,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 563 126 2
 Refer: 270 85 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uacute.sc
 EndChar
 
 StartChar: Ucircumflex
@@ -8547,8 +8547,8 @@ LayerCount: 2
 Fore
 Refer: 1680 858 N 1 0 0 1 482 166 2
 Refer: 270 85 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ucircumflex.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ucircumflex.sc
 EndChar
 
 StartChar: Udieresis.alt
@@ -8613,8 +8613,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 517 127 2
 Refer: 274 89 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" yacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" yacute.sc
 EndChar
 
 StartChar: Thorn
@@ -8663,8 +8663,8 @@ SplineSet
  309 -1 l 1
  309 -1 199 1 160 1 c 0
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" thorn.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" thorn.sc
 EndChar
 
 StartChar: germandbls
@@ -8712,8 +8712,8 @@ SplineSet
  27 422 33 434 50 434 c 0
  81 434 92 455 92 482 c 0
 EndSplineSet
-Substitution2: "'ss03' Stilgruppe 3 1" germandbls.ss03
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" germandbls.ss03
 EndChar
 
 StartChar: agrave
@@ -9110,8 +9110,8 @@ LayerCount: 2
 Fore
 Refer: 1734 860 N 1 0 0 1 519 147 2
 Refer: 24 65 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" abreve.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" abreve.sc
 EndChar
 
 StartChar: abreve
@@ -9199,8 +9199,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 549 126 2
 Refer: 26 67 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" cacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" cacute.sc
 EndChar
 
 StartChar: cacute
@@ -9264,8 +9264,8 @@ LayerCount: 2
 Fore
 Refer: 1733 859 N 1 0 0 1 538 173 2
 Refer: 26 67 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ccaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ccaron.sc
 EndChar
 
 StartChar: ccaron
@@ -9287,8 +9287,8 @@ LayerCount: 2
 Fore
 Refer: 1733 859 N 1 0 0 1 496 173 2
 Refer: 27 68 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" dcaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" dcaron.sc
 EndChar
 
 StartChar: dcaron
@@ -9310,8 +9310,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 359 208 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" dcroat.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" dcroat.sc
 EndChar
 
 StartChar: dcroat
@@ -9406,8 +9406,8 @@ LayerCount: 2
 Fore
 Refer: 259 74 N 1 0 0 1 297 0 2
 Refer: 258 73 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ij.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ij.sc
 EndChar
 
 StartChar: ij
@@ -9577,8 +9577,8 @@ LayerCount: 2
 Fore
 Refer: 655 700 N 1 0 0 1 321 46 2
 Refer: 261 76 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" lcaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" lcaron.sc
 EndChar
 
 StartChar: lcaron
@@ -9656,8 +9656,8 @@ SplineSet
  222 398.8 l 1
  310 449 l 1
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" lslash.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" lslash.sc
 EndChar
 
 StartChar: lslash
@@ -9709,8 +9709,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 540 127 2
 Refer: 263 78 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" nacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" nacute.sc
 EndChar
 
 StartChar: nacute
@@ -9753,8 +9753,8 @@ LayerCount: 2
 Fore
 Refer: 1733 859 N 1 0 0 1 536 173 2
 Refer: 263 78 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ncaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ncaron.sc
 EndChar
 
 StartChar: ncaron
@@ -9824,10 +9824,10 @@ SplineSet
  176 645 221 647 221 647 c 1
  221 76 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
-Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" eng.sc
+Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 Comment: "Sieht in Times anders aus"
 EndChar
 
@@ -9927,8 +9927,8 @@ LayerCount: 2
 Fore
 Refer: 1735 861 N 1 0 0 1 604 88 2
 Refer: 264 79 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ohungarumlaut.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ohungarumlaut.sc
 EndChar
 
 StartChar: ohungarumlaut
@@ -10034,8 +10034,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 469 127 2
 Refer: 267 82 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" racute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" racute.sc
 EndChar
 
 StartChar: racute
@@ -10078,8 +10078,8 @@ LayerCount: 2
 Fore
 Refer: 1733 859 N 1 0 0 1 449 173 2
 Refer: 267 82 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" rcaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" rcaron.sc
 EndChar
 
 StartChar: rcaron
@@ -10101,8 +10101,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 439 127 2
 Refer: 268 83 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" sacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" sacute.sc
 EndChar
 
 StartChar: sacute
@@ -10170,8 +10170,8 @@ LayerCount: 2
 Fore
 Refer: 1733 859 N 1 0 0 1 420 173 2
 Refer: 268 83 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" scaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" scaron.sc
 EndChar
 
 StartChar: scaron
@@ -10218,8 +10218,8 @@ LayerCount: 2
 Fore
 Refer: 1733 859 N 1 0 0 1 476 173 2
 Refer: 269 84 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" tcaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" tcaron.sc
 EndChar
 
 StartChar: tcaron
@@ -10341,8 +10341,8 @@ LayerCount: 2
 Fore
 Refer: 1413 778 N 1 0 0 1 530 70 2
 Refer: 270 85 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uring.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uring.sc
 EndChar
 
 StartChar: uring
@@ -10364,8 +10364,8 @@ LayerCount: 2
 Fore
 Refer: 1735 861 N 1 0 0 1 616 88 2
 Refer: 270 85 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uhungarumlaut.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" uhungarumlaut.sc
 EndChar
 
 StartChar: uhungarumlaut
@@ -10530,8 +10530,8 @@ LayerCount: 2
 Fore
 Refer: 674 776 N 1 0 0 1 503 176 2
 Refer: 274 89 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ydieresis.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" ydieresis.sc
 EndChar
 
 StartChar: Zacute
@@ -10542,8 +10542,8 @@ LayerCount: 2
 Fore
 Refer: 1681 857 N 1 0 0 1 505 127 2
 Refer: 275 90 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" zacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" zacute.sc
 EndChar
 
 StartChar: zacute
@@ -10587,8 +10587,8 @@ LayerCount: 2
 Fore
 Refer: 1733 859 N 1 0 0 1 485 174 2
 Refer: 275 90 N 1 0 0 1 0 0 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" zcaron.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" zcaron.sc
 EndChar
 
 StartChar: zcaron
@@ -12301,8 +12301,8 @@ LayerCount: 2
 Fore
 Refer: 349 198 N 1 0 0 1 0 0 2
 Refer: 1681 857 N 1 0 0 1 775 128 2
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" aeacute.sc
 EndChar
 
 StartChar: aeacute
@@ -20504,8 +20504,8 @@ SplineSet
  52 232 l 1
  123 282 194 347 296 457 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guilsinglleft.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guilsinglleft.sc
+Substitution2: "'case' Versalformen 1" guilsinglleft.sc
 EndChar
 
 StartChar: guilsinglright
@@ -20524,8 +20524,8 @@ SplineSet
  304 198 l 1
  233 148 162 83 60 -27 c 1
 EndSplineSet
-Substitution2: "'case' Versalformen 1" guilsinglright.sc
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" guilsinglright.sc
+Substitution2: "'case' Versalformen 1" guilsinglright.sc
 EndChar
 
 StartChar: exclamdbl
@@ -22106,9 +22106,9 @@ SplineSet
 EndSplineSet
 Refer: 336 185 N 1 0 0 1 -14 -49 2
 Refer: 330 179 N 1 0 0 1 358 -443 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction three
 Ligature2: "'frac' Brueche 1" one slash three
-LCarets2: 2 0 0
 EndChar
 
 StartChar: twothirds
@@ -22126,9 +22126,9 @@ SplineSet
 EndSplineSet
 Refer: 330 179 N 1 0 0 1 352 -445 2
 Refer: 329 178 N 1 0 0 1 0 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" two fraction three
 Ligature2: "'frac' Brueche 1" two slash three
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2155
@@ -22146,9 +22146,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 351 -445 2
 Refer: 336 185 N 1 0 0 1 -7 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction five
 Ligature2: "'frac' Brueche 1" one slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2156
@@ -22166,9 +22166,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 352 -444 2
 Refer: 329 178 N 1 0 0 1 1 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" two fraction five
 Ligature2: "'frac' Brueche 1" two slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2157
@@ -22186,9 +22186,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 349 -444 2
 Refer: 330 179 N 1 0 0 1 -1 -49 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three fraction five
 Ligature2: "'frac' Brueche 1" three slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni2158
@@ -22206,9 +22206,9 @@ SplineSet
 EndSplineSet
 Refer: 1074 8309 N 1 0 0 1 353 -444 2
 Refer: 1073 8308 N 1 0 0 1 -9 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" four fraction five
 Ligature2: "'frac' Brueche 1" four slash five
-LCarets2: 2 0 0
 EndChar
 
 StartChar: oneeighth
@@ -22226,9 +22226,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 348 -446 2
 Refer: 336 185 N 1 0 0 1 -7 -49 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction eight
 Ligature2: "'frac' Brueche 1" one slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: threeeighths
@@ -22246,9 +22246,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 347 -444 2
 Refer: 330 179 N 1 0 0 1 2 -50 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" three fraction eight
 Ligature2: "'frac' Brueche 1" three slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: fiveeighths
@@ -22266,9 +22266,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 342 -445 2
 Refer: 1074 8309 N 1 0 0 1 -4 -48 2
-Ligature2: "'frac' Brueche 1" three fraction eight
-Ligature2: "'frac' Brueche 1" five slash eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five slash eight
+Ligature2: "'frac' Brueche 1" three fraction eight
 EndChar
 
 StartChar: seveneighths
@@ -22286,9 +22286,9 @@ SplineSet
 EndSplineSet
 Refer: 1077 8312 N 1 0 0 1 352 -444 2
 Refer: 1076 8311 N 1 0 0 1 1 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" seven fraction eight
 Ligature2: "'frac' Brueche 1" seven slash eight
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni215F
@@ -31517,8 +31517,8 @@ SplineSet
  397 426 l 2
  397 432 415 434 435 434 c 0
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" s t
 LCarets2: 1 375
+Ligature2: "'hlig' Historische Ligaturen 1" s t
 EndChar
 
 StartChar: uni02B0
@@ -34938,9 +34938,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8310 N 1 0 0 1 345 -445 2
 Refer: 336 185 N 1 0 0 1 -2 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" one fraction six
 Ligature2: "'frac' Brueche 1" one slash six
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni215A
@@ -34958,9 +34958,9 @@ SplineSet
 EndSplineSet
 Refer: 1075 8310 N 1 0 0 1 344 -444 2
 Refer: 1074 8309 N 1 0 0 1 -1 -48 2
+LCarets2: 2 0 0
 Ligature2: "'frac' Brueche 1" five fraction six
 Ligature2: "'frac' Brueche 1" five slash six
-LCarets2: 2 0 0
 EndChar
 
 StartChar: uni221B
@@ -42076,8 +42076,8 @@ LayerCount: 2
 Fore
 Refer: 257 48 N 1 0 0 1 5 0 2
 Substitution2: "'case' Versalformen Figures" zero.cap.fitted
-Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 Substitution2: "'tnum' Tabellenziffern 1" zero
+Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 EndChar
 
 StartChar: semicolon
@@ -47879,8 +47879,8 @@ SplineSet
  95 563 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" l.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E1
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" l.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E1
 EndChar
 
 StartChar: s
@@ -47909,8 +47909,8 @@ SplineSet
  49 50 44 94 37 146 c 1
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" s.inferior
-Substitution2: "'sups' Hochgestellte 1" uni02E2
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" s.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E2
 EndChar
 
 StartChar: x
@@ -47975,8 +47975,8 @@ SplineSet
  183 73 l 2
 EndSplineSet
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2093
-Substitution2: "'sups' Hochgestellte 1" uni02E3
 Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" x.sc
+Substitution2: "'sups' Hochgestellte 1" uni02E3
 EndChar
 
 StartChar: uni03D8
@@ -54267,8 +54267,8 @@ SplineSet
  148 58 196 28 240 28 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" eight.cap
-Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'onum' Minuskelziffern 1" eight.taboldstyle
+Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
 Substitution2: "'sups' Hochgestellte 1" uni2078
 EndChar
@@ -54373,8 +54373,8 @@ SplineSet
  40 33 l 2
  81 33 94 49 94 76 c 2
 EndSplineSet
-Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" germandbls.sc
+Substitution2: "'ss03' Stilgruppe 3 1" uni1E9E.alt
 EndChar
 
 StartChar: uni2201
@@ -55201,8 +55201,8 @@ SplineSet
  502 367 l 1
  502 569 l 2
 EndSplineSet
-Substitution2: "'c2sc' Versale nach Kapitaelchen 1" h.sc
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'c2sc' Versale nach Kapitaelchen 1" h.sc
 EndChar
 
 StartChar: germandbls.sc
@@ -55430,8 +55430,8 @@ SplineSet
  37 316.7 101.2 404.3 188.2 433.5 c 1
  160.1 446.7 149 462.6 149 479 c 0
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" c t
 LCarets2: 1 422
+Ligature2: "'hlig' Historische Ligaturen 1" c t
 EndChar
 
 StartChar: h.alt
@@ -55538,8 +55538,8 @@ SplineSet
  134 -10 38 74 38 221 c 0
  38 352 137 444 246 444 c 0
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 Substitution2: "'lnum' Versalziffern 1" zero
+Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 EndChar
 
 StartChar: one.taboldstyle
@@ -55549,8 +55549,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 1374 -1 N 1 0 0 1 47 0 2
-Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 Substitution2: "'lnum' Versalziffern 1" one
+Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 EndChar
 
 StartChar: two.taboldstyle
@@ -55578,8 +55578,8 @@ SplineSet
  190 75 l 1
  301 82 l 2
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 Substitution2: "'lnum' Versalziffern 1" two
+Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 EndChar
 
 StartChar: three.taboldstyle
@@ -55589,8 +55589,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 1456 -1 N 1 0 0 1 4 -166 2
-Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 Substitution2: "'lnum' Versalziffern 1" three
+Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 EndChar
 
 StartChar: four.taboldstyle
@@ -55600,8 +55600,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 13 52 N 1 0 0 1 -8 -169 2
-Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 Substitution2: "'lnum' Versalziffern 1" four
+Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 EndChar
 
 StartChar: five.taboldstyle
@@ -55611,8 +55611,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 14 53 N 1 0 0 1 -7 -167 2
-Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 Substitution2: "'lnum' Versalziffern 1" five
+Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 EndChar
 
 StartChar: six.taboldstyle
@@ -55622,8 +55622,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 15 54 N 1 0 0 1 -2 0 2
-Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 Substitution2: "'lnum' Versalziffern 1" six
+Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 EndChar
 
 StartChar: seven.taboldstyle
@@ -55633,8 +55633,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 16 55 N 1 0 0 1 -4 -158 2
-Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 Substitution2: "'lnum' Versalziffern 1" seven
+Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 EndChar
 
 StartChar: nine.taboldstyle
@@ -55644,8 +55644,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 17 57 N 1 0 0 1 -0.5 -166 2
-Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 Substitution2: "'lnum' Versalziffern 1" nine
+Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 EndChar
 
 StartChar: uni26A5
@@ -56109,9 +56109,9 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 2168 56 N 1 0 0 1 0 0 2
-Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 EndChar
 
 StartChar: zero.slash

--- a/sources/LibertinusSerif-SemiboldItalic.sfd
+++ b/sources/LibertinusSerif-SemiboldItalic.sfd
@@ -689,11 +689,11 @@ SplineSet
 EndSplineSet
 Kerns2: 12 -4 "'kern' Horizontales Kerning in Latin lookup 1"
 Substitution2: "'case' Versalformen Figures" zero.cap
-Substitution2: "'zero' gestrichene Null 1" zero.slash
-Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
-Substitution2: "'sups' Superscript in Latin lookup 6" uni2070
+Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2080
+Substitution2: "'sups' Superscript in Latin lookup 6" uni2070
+Substitution2: "'zero' gestrichene Null 1" zero.slash
 EndChar
 
 StartChar: one
@@ -723,10 +723,10 @@ SplineSet
  311 122 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" one.cap
-Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'onum' Minuskelziffern 1" one.taboldstyle
-Substitution2: "'sups' Superscript in Latin lookup 6" uni00B9
+Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2081
+Substitution2: "'sups' Superscript in Latin lookup 6" uni00B9
 EndChar
 
 StartChar: two
@@ -763,10 +763,10 @@ SplineSet
  126 509 171 556 230 585 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" two.cap
-Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'onum' Minuskelziffern 1" two.taboldstyle
-Substitution2: "'sups' Superscript in Latin lookup 6" uni00B2
+Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2082
+Substitution2: "'sups' Superscript in Latin lookup 6" uni00B2
 EndChar
 
 StartChar: three
@@ -803,10 +803,10 @@ SplineSet
  391 536 357 564 318 564 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" three.cap
-Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'onum' Minuskelziffern 1" three.taboldstyle
-Substitution2: "'sups' Superscript in Latin lookup 6" uni00B3
+Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2083
+Substitution2: "'sups' Superscript in Latin lookup 6" uni00B3
 EndChar
 
 StartChar: four
@@ -844,10 +844,10 @@ SplineSet
  470 211 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" four.cap
-Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'onum' Minuskelziffern 1" four.taboldstyle
-Substitution2: "'sups' Superscript in Latin lookup 6" uni2074
+Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2084
+Substitution2: "'sups' Superscript in Latin lookup 6" uni2074
 EndChar
 
 StartChar: five
@@ -883,10 +883,10 @@ SplineSet
  320 96 343 142 343 205 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" five.cap
-Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'onum' Minuskelziffern 1" five.taboldstyle
-Substitution2: "'sups' Superscript in Latin lookup 6" uni2075
+Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2085
+Substitution2: "'sups' Superscript in Latin lookup 6" uni2075
 EndChar
 
 StartChar: six
@@ -917,10 +917,10 @@ SplineSet
  255 322 230 316 185 286 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" six.cap
-Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'onum' Minuskelziffern 1" six.taboldstyle
-Substitution2: "'sups' Superscript in Latin lookup 6" uni2076
+Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2086
+Substitution2: "'sups' Superscript in Latin lookup 6" uni2076
 EndChar
 
 StartChar: seven
@@ -948,10 +948,10 @@ SplineSet
 EndSplineSet
 Kerns2: 12 -44 "'kern' Horizontales Kerning in Latin lookup 1" 14 -44 "'kern' Horizontales Kerning in Latin lookup 1"
 Substitution2: "'case' Versalformen Figures" seven.cap
-Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'onum' Minuskelziffern 1" seven.taboldstyle
-Substitution2: "'sups' Superscript in Latin lookup 6" uni2077
+Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2087
+Substitution2: "'sups' Superscript in Latin lookup 6" uni2077
 EndChar
 
 StartChar: eight
@@ -993,10 +993,10 @@ SplineSet
  410 535 382 574 338 574 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" eight.cap
-Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'onum' Minuskelziffern 1" eight.taboldstyle
-Substitution2: "'sups' Superscript in Latin lookup 6" uni2078
+Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2088
+Substitution2: "'sups' Superscript in Latin lookup 6" uni2078
 EndChar
 
 StartChar: nine
@@ -1027,10 +1027,10 @@ SplineSet
  312 278 337 283 382 313 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" nine.cap
-Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'onum' Minuskelziffern 1" nine.taboldstyle
-Substitution2: "'sups' Superscript in Latin lookup 6" uni2079
+Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2089
+Substitution2: "'sups' Superscript in Latin lookup 6" uni2079
 EndChar
 
 StartChar: colon
@@ -2653,8 +2653,8 @@ SplineSet
  351 -10 340 21 340 39 c 0
 EndSplineSet
 Kerns2: 116 -13 "'kern' Horizontales Kerning in Latin lookup 1"
-Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" a.sc
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2090
+Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" a.sc
 EndChar
 
 StartChar: b
@@ -2804,8 +2804,8 @@ SplineSet
  454 444 475 405 475 369 c 0
 EndSplineSet
 Kerns2: 12 -4 "'kern' Horizontales Kerning in Latin lookup 1" 14 -4 "'kern' Horizontales Kerning in Latin lookup 1" 52 -68 "'kern' Horizontales Kerning in Latin lookup 1" 67 12 "'kern' Horizontales Kerning in Latin lookup 1" 68 12 "'kern' Horizontales Kerning in Latin lookup 1" 81 12 "'kern' Horizontales Kerning in Latin lookup 1" 84 -9 "'kern' Horizontales Kerning in Latin lookup 1" 86 -9 "'kern' Horizontales Kerning in Latin lookup 1" 87 -9 "'kern' Horizontales Kerning in Latin lookup 1" 88 -12 "'kern' Horizontales Kerning in Latin lookup 1"
-Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" e.sc
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2091
+Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" e.sc
 EndChar
 
 StartChar: f
@@ -3181,8 +3181,8 @@ SplineSet
  103 -10 72 111 72 165 c 0
 EndSplineSet
 Kerns2: 14 -4 "'kern' Horizontales Kerning in Latin lookup 1" 52 -62 "'kern' Horizontales Kerning in Latin lookup 1" 67 11 "'kern' Horizontales Kerning in Latin lookup 1" 68 11 "'kern' Horizontales Kerning in Latin lookup 1" 81 11 "'kern' Horizontales Kerning in Latin lookup 1" 84 -9 "'kern' Horizontales Kerning in Latin lookup 1" 86 -9 "'kern' Horizontales Kerning in Latin lookup 1" 87 -9 "'kern' Horizontales Kerning in Latin lookup 1" 88 -11 "'kern' Horizontales Kerning in Latin lookup 1" 89 -9 "'kern' Horizontales Kerning in Latin lookup 1"
-Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" o.sc
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2092
+Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" o.sc
 EndChar
 
 StartChar: p
@@ -3544,8 +3544,8 @@ SplineSet
  240.7 255.3 201.7 340 201.7 340 c 2
 EndSplineSet
 Kerns2: 69 -11 "'kern' Horizontales Kerning in Latin lookup 1" 79 -11 "'kern' Horizontales Kerning in Latin lookup 1"
-Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" x.sc
 Substitution2: "'sinf' Wissenschaftliche Indices in Latin lookup 5" uni2093
+Substitution2: "'smcp' Gemeine nach Kapitaelchen 1" x.sc
 EndChar
 
 StartChar: y
@@ -4645,8 +4645,8 @@ SplineSet
  206 339 219 354 224 383 c 2
 EndSplineSet
 LCarets2: 2 0 0
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash four
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one fraction four
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash four
 EndChar
 
 StartChar: onehalf
@@ -4702,8 +4702,8 @@ SplineSet
  209 339 221 354 227 383 c 2
 EndSplineSet
 LCarets2: 2 0 0
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash two
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one fraction two
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash two
 EndChar
 
 StartChar: threequarters
@@ -4768,8 +4768,8 @@ SplineSet
  656 184 l 1
 EndSplineSet
 LCarets2: 2 0 0
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" three slash four
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" three fraction four
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" three slash four
 EndChar
 
 StartChar: questiondown
@@ -7896,8 +7896,8 @@ SplineSet
  338 645 355 646 375 647 c 1
  284 122 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 EndChar
 
 StartChar: eng
@@ -39709,8 +39709,8 @@ SplineSet
  162 339 l 2
  196 339 208 354 214 383 c 2
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash three
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one fraction three
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash three
 EndChar
 
 StartChar: twothirds
@@ -39773,8 +39773,8 @@ SplineSet
  503 103 l 1
  547 108 589 136 597 175 c 0
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" two slash three
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" two fraction three
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" two slash three
 EndChar
 
 StartChar: uni2155
@@ -39831,8 +39831,8 @@ SplineSet
  169 340 l 2
  203 340 215 356 221 384 c 2
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash five
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one fraction five
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash five
 EndChar
 
 StartChar: uni2156
@@ -39889,8 +39889,8 @@ SplineSet
  256 568 256 558 256 556 c 0
  252 538 223 525 207 525 c 0
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" two slash five
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" two fraction five
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" two slash five
 EndChar
 
 StartChar: uni2157
@@ -39951,8 +39951,8 @@ SplineSet
  485 -40 493 -49 505 -49 c 0
  538 -49 560 -13 567 26 c 0
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" three slash five
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" three fraction five
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" three slash five
 EndChar
 
 StartChar: uni2158
@@ -40016,8 +40016,8 @@ SplineSet
  489 -40 497 -49 509 -49 c 0
  542 -49 563 -13 571 26 c 0
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" four slash five
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" four fraction five
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" four slash five
 EndChar
 
 StartChar: uni2159
@@ -40073,8 +40073,8 @@ SplineSet
  174 340 l 2
  208 340 220 356 226 384 c 2
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash six
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one fraction six
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash six
 EndChar
 
 StartChar: uni215A
@@ -40128,8 +40128,8 @@ SplineSet
  646 119 660 68 660 40 c 0
  660 33 659 27 659 24 c 0
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" five slash six
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" five fraction six
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" five slash six
 EndChar
 
 StartChar: oneeighth
@@ -40199,8 +40199,8 @@ SplineSet
  169 339 l 2
  203 339 215 354 221 383 c 2
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash eight
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one fraction eight
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" one slash eight
 EndChar
 
 StartChar: threeeighths
@@ -40275,8 +40275,8 @@ SplineSet
  634 249 678 224 678 188 c 0
  678 184 677 181 677 178 c 0
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" three slash eight
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" three fraction eight
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" three slash eight
 EndChar
 
 StartChar: fiveeighths
@@ -40343,8 +40343,8 @@ SplineSet
  628 248 672 223 672 187 c 0
  672 183 672 180 671 177 c 0
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" five slash eight
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" five fraction eight
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" five slash eight
 EndChar
 
 StartChar: seveneighths
@@ -40405,8 +40405,8 @@ SplineSet
  639 249 683 224 683 187 c 0
  683 184 683 181 682 177 c 0
 EndSplineSet
-Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" seven slash eight
 Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" seven fraction eight
+Ligature2: "'frac' Diagonal Fractions in Latin lookup 2" seven slash eight
 EndChar
 
 StartChar: uni215F
@@ -48046,8 +48046,8 @@ LayerCount: 2
 Fore
 Refer: 16 48 N 1 0 0 1 6 0 2
 Substitution2: "'case' Versalformen Figures" zero.cap.fitted
-Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 Substitution2: "'tnum' Tabellenziffern 1" zero
+Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 EndChar
 
 StartChar: one.fitted
@@ -48336,8 +48336,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 24 56 N 1 0 0 1 11 -1 2
-Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
+Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 EndChar
 
 StartChar: nine.oldstyle
@@ -51811,8 +51811,8 @@ SplineSet
  354.2 452.5 360.4 444.6 367.1 438.2 c 1
  367.569060773 438.066298343 367.812154696 437.972375691 368.100585938 437.899414062 c 0
 EndSplineSet
-Ligature2: "'hlig' Historic Ligatures in Latin lookup 13-1" s t
 LCarets2: 1 365
+Ligature2: "'hlig' Historic Ligatures in Latin lookup 13-1" s t
 EndChar
 
 StartChar: uniFFFD
@@ -67447,8 +67447,8 @@ SplineSet
  406 413 357 374 307 300 c 1
  274 122 l 2
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle.sc
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle.sc
 EndChar
 
 StartChar: ohungarumlaut.sc
@@ -68615,8 +68615,8 @@ SplineSet
  132 -10 52 74 81 221 c 0
  106 352 223 444 332 444 c 0
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 Substitution2: "'lnum' Versalziffern 1" zero
+Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 EndChar
 
 StartChar: one.taboldstyle
@@ -68626,8 +68626,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 1737 -1 N 1 0 0 1 47 0 2
-Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 Substitution2: "'lnum' Versalziffern 1" one
+Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 EndChar
 
 StartChar: two.taboldstyle
@@ -68637,8 +68637,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 1738 -1 N 1 0 0 1 -11 0 2
-Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 Substitution2: "'lnum' Versalziffern 1" two
+Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 EndChar
 
 StartChar: three.taboldstyle
@@ -68648,8 +68648,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 19 51 N 1 0 0 1 -40 -167 2
-Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 Substitution2: "'lnum' Versalziffern 1" three
+Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 EndChar
 
 StartChar: four.taboldstyle
@@ -68659,8 +68659,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 20 52 N 1 0 0 1 -17 -169 2
-Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 Substitution2: "'lnum' Versalziffern 1" four
+Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 EndChar
 
 StartChar: five.taboldstyle
@@ -68670,8 +68670,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 21 53 N 1 0 0 1 -35 -170 2
-Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 Substitution2: "'lnum' Versalziffern 1" five
+Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 EndChar
 
 StartChar: six.taboldstyle
@@ -68681,8 +68681,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 22 54 N 1 0 0 1 13 0 2
-Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 Substitution2: "'lnum' Versalziffern 1" six
+Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 EndChar
 
 StartChar: seven.taboldstyle
@@ -68692,8 +68692,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 23 55 N 1 0 0 1 -24 -159 2
-Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 Substitution2: "'lnum' Versalziffern 1" seven
+Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 EndChar
 
 StartChar: eight.taboldstyle
@@ -68713,8 +68713,8 @@ Flags: MW
 LayerCount: 2
 Fore
 Refer: 25 57 N 1 0 0 1 -12 -154 2
-Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 Substitution2: "'lnum' Versalziffern 1" nine
+Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 EndChar
 
 StartChar: uniE01A

--- a/sources/LibertinusSerifDisplay-Regular.sfd
+++ b/sources/LibertinusSerifDisplay-Regular.sfd
@@ -503,9 +503,9 @@ SplineSet
  48 -24 44 207 44 252 c 0
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenleft.sc
+Substitution2: "'case' Versalformen 1" parenleft.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208D
 Substitution2: "'sups' Hochgestellte 1" uni207D
-Substitution2: "'case' Versalformen 1" parenleft.sc
 EndChar
 
 StartChar: parenright
@@ -524,9 +524,9 @@ SplineSet
  250 528 254 297 254 252 c 0
 EndSplineSet
 Substitution2: "'c2sc' Versale nach Kapitaelchen 1" parenright.sc
+Substitution2: "'case' Versalformen 1" parenright.sc
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208E
 Substitution2: "'sups' Hochgestellte 1" uni207E
-Substitution2: "'case' Versalformen 1" parenright.sc
 Colour: ff00ff
 EndChar
 
@@ -597,8 +597,8 @@ SplineSet
  252 646 l 1
  288 646 l 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" fraction
 Ligature2: "'frac' Brueche 1" uni2215
+Substitution2: "'sups' Hochgestellte 1" fraction
 EndChar
 
 StartChar: one
@@ -627,10 +627,10 @@ SplineSet
  283.5 214.5 284 139 285 109 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" one.cap
-Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'onum' Minuskelziffern 1" one.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni00B9
+Substitution2: "'pnum' Proportionalziffern 1" one.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2081
+Substitution2: "'sups' Hochgestellte 1" uni00B9
 EndChar
 
 StartChar: two
@@ -664,10 +664,10 @@ SplineSet
  80 436 61 447 61 468 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" two.cap
-Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'onum' Minuskelziffern 1" two.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni00B2
+Substitution2: "'pnum' Proportionalziffern 1" two.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2082
+Substitution2: "'sups' Hochgestellte 1" uni00B2
 EndChar
 
 StartChar: three
@@ -699,10 +699,10 @@ SplineSet
  309 551 263 585 219 585 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" three.cap
-Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'onum' Minuskelziffern 1" three.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni00B3
+Substitution2: "'pnum' Proportionalziffern 1" three.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2083
+Substitution2: "'sups' Hochgestellte 1" uni00B3
 EndChar
 
 StartChar: four
@@ -739,10 +739,10 @@ SplineSet
  423 209 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" four.cap
-Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'onum' Minuskelziffern 1" four.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2074
+Substitution2: "'pnum' Proportionalziffern 1" four.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2084
+Substitution2: "'sups' Hochgestellte 1" uni2074
 EndChar
 
 StartChar: five
@@ -773,10 +773,10 @@ SplineSet
  269 14 325 94 325 189 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" five.cap
-Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'onum' Minuskelziffern 1" five.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2075
+Substitution2: "'pnum' Proportionalziffern 1" five.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2085
+Substitution2: "'sups' Hochgestellte 1" uni2075
 EndChar
 
 StartChar: six
@@ -803,10 +803,10 @@ SplineSet
  226.9 534.4 163.3 431 137 339 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" six.cap
-Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'onum' Minuskelziffern 1" six.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2076
+Substitution2: "'pnum' Proportionalziffern 1" six.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2086
+Substitution2: "'sups' Hochgestellte 1" uni2076
 EndChar
 
 StartChar: seven
@@ -832,10 +832,10 @@ SplineSet
  160 545 l 2
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" seven.cap
-Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'onum' Minuskelziffern 1" seven.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2077
+Substitution2: "'pnum' Proportionalziffern 1" seven.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2087
+Substitution2: "'sups' Hochgestellte 1" uni2077
 EndChar
 
 StartChar: nine
@@ -862,10 +862,10 @@ SplineSet
  244.1 64.6 307.7 168 334 260 c 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" nine.cap
-Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'onum' Minuskelziffern 1" nine.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2079
+Substitution2: "'pnum' Proportionalziffern 1" nine.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2089
+Substitution2: "'sups' Hochgestellte 1" uni2079
 Colour: ff00ff
 EndChar
 
@@ -10952,9 +10952,9 @@ SplineSet
  294 275 298 275 298 265 c 0
  298 253 284 231 271 231 c 2
 EndSplineSet
+Substitution2: "'case' Versalformen 1" hyphen.cap
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni208B
 Substitution2: "'sups' Hochgestellte 1" uni207B
-Substitution2: "'case' Versalformen 1" hyphen.cap
 EndChar
 
 StartChar: period
@@ -10994,11 +10994,11 @@ SplineSet
  422 68 305 -10 228 -10 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" zero.cap
-Substitution2: "'zero' gestrichene Null 1" zero.slash
-Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'onum' Minuskelziffern 1" zero.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'pnum' Proportionalziffern 1" zero.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
+Substitution2: "'sups' Hochgestellte 1" uni2070
+Substitution2: "'zero' gestrichene Null 1" zero.slash
 EndChar
 
 StartChar: I
@@ -11601,8 +11601,8 @@ SplineSet
  683.5 109 l 1
  842.5 565 l 2
 EndSplineSet
-Substitution2: "'ss05' Stilgruppe 5" W.alt
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'ss05' Stilgruppe 5" W.alt
 EndChar
 
 StartChar: X
@@ -11877,8 +11877,8 @@ SplineSet
  441 28 407 -10 360 -10 c 0
  309 -10 294 26 288 46 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni1D43
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2090
+Substitution2: "'sups' Hochgestellte 1" uni1D43
 EndChar
 
 StartChar: b
@@ -12028,8 +12028,8 @@ SplineSet
  171 47 221 27 255 27 c 0
  310 27 343 53 378 89 c 1
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni1D49
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2091
+Substitution2: "'sups' Hochgestellte 1" uni1D49
 EndChar
 
 StartChar: f
@@ -12208,9 +12208,9 @@ SplineSet
  174 189.5 174.9 139 176 109 c 0
 EndSplineSet
 Refer: 256 46 N 1 0 0 1 20 552 2
-Substitution2: "Substitution dotless forms 1" dotlessi
 Substitution2: "'sinf' Wissenschaftliche Indices 1" i.inferior
 Substitution2: "'sups' Hochgestellte 1" uni2071
+Substitution2: "Substitution dotless forms 1" dotlessi
 Colour: ff00ff
 EndChar
 
@@ -12242,9 +12242,9 @@ SplineSet
  115.8 234.9 114.7 273.9 113 307 c 0
 EndSplineSet
 Refer: 256 46 N 1 0 0 1 39 552 2
-Substitution2: "Substitution dotless forms 1" uni0237
 Substitution2: "'sinf' Wissenschaftliche Indices 1" j.inferior
 Substitution2: "'sups' Hochgestellte 1" uni02B2
+Substitution2: "Substitution dotless forms 1" uni0237
 Colour: ff00ff
 EndChar
 
@@ -12460,8 +12460,8 @@ SplineSet
  299 13 366 54 366 174 c 0
  366 311 310 396 228 396 c 0
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni1D52
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2092
+Substitution2: "'sups' Hochgestellte 1" uni1D52
 EndChar
 
 StartChar: p
@@ -13851,8 +13851,8 @@ SplineSet
  146 530 l 2
  146 562 144 571 132 571 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" one slash four
 LCarets2: 2 215 424
+Ligature2: "'frac' Brueche 1" one slash four
 Colour: ff9ccc
 EndChar
 
@@ -18372,9 +18372,9 @@ SplineSet
  75 649 98 645 148 645 c 0
  161 645 172 648 181 649 c 0
 EndSplineSet
-Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
-Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
 Position2: "'cpsp' Versalabstaende 1" dx=2 dy=0 dh=5 dv=0
+Substitution2: "'locl' Localised Forms for Sami-1" Eng.UCStyle
+Substitution2: "'ss07' Swap 'Eng' forms-1" Eng.UCStyle
 Comment: "Sieht in Times anders aus"
 EndChar
 
@@ -26156,8 +26156,8 @@ SplineSet
  -228 641 -205 658 -171 658 c 0
  -166 658 -160 657 -156 656 c 1
 EndSplineSet
-Substitution2: "Substitution cap-Accents 1" grave.cap
 Substitution2: "'case' Versalformen 1" uni0358
+Substitution2: "Substitution cap-Accents 1" grave.cap
 EndChar
 
 StartChar: acutecomb
@@ -26181,8 +26181,8 @@ SplineSet
  -239 520.2 -235.7 524.2 -227.6 537 c 2
  -152 656 l 1
 EndSplineSet
-Substitution2: "Substitution cap-Accents 1" acute.cap
 Substitution2: "'case' Versalformen 1" uni0359
+Substitution2: "Substitution cap-Accents 1" acute.cap
 EndChar
 
 StartChar: uni0302
@@ -26204,8 +26204,8 @@ SplineSet
  -230 556 -184 610 -155 656 c 1
  -144.3 658.3 -133.8 658.5 -123 656 c 1
 EndSplineSet
-Substitution2: "Substitution cap-Accents 1" circumflex.cap
 Substitution2: "'case' Versalformen 1" uni035A
+Substitution2: "Substitution cap-Accents 1" circumflex.cap
 EndChar
 
 StartChar: tildecomb
@@ -43499,9 +43499,9 @@ SplineSet
  135 530 l 2
  135 562 133 571 121 571 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" one slash three
-Ligature2: "'frac' Brueche 1" one fraction three
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction three
+Ligature2: "'frac' Brueche 1" one slash three
 Colour: ff9ccc
 EndChar
 
@@ -43554,9 +43554,9 @@ SplineSet
  463.6 85.5 464.3 96.9 467 106 c 1
  511 112 538 138 538 179 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" two slash three
-Ligature2: "'frac' Brueche 1" two fraction three
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" two fraction three
+Ligature2: "'frac' Brueche 1" two slash three
 Colour: ff9ccc
 EndChar
 
@@ -43605,9 +43605,9 @@ SplineSet
  142 531 l 2
  142 563 140 572 128 572 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" one slash five
-Ligature2: "'frac' Brueche 1" one fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction five
+Ligature2: "'frac' Brueche 1" one slash five
 Colour: ff9ccc
 EndChar
 
@@ -43659,9 +43659,9 @@ SplineSet
  99.5 580.7 102.3 567.9 101 560 c 0
  98 542 84 539 74 539 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" two slash five
-Ligature2: "'frac' Brueche 1" two fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" two fraction five
+Ligature2: "'frac' Brueche 1" two slash five
 Colour: ff9ccc
 EndChar
 
@@ -43715,9 +43715,9 @@ SplineSet
  457 -51 468 -58 490 -58 c 0
  535 -58 552 -23 552 18 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" three slash five
-Ligature2: "'frac' Brueche 1" three fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three fraction five
+Ligature2: "'frac' Brueche 1" three slash five
 Colour: ff9ccc
 EndChar
 
@@ -43775,9 +43775,9 @@ SplineSet
  461 -51 472 -58 494 -58 c 0
  539 -58 556 -23 556 18 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" four slash five
-Ligature2: "'frac' Brueche 1" four fraction five
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" four fraction five
+Ligature2: "'frac' Brueche 1" four slash five
 Colour: ff9ccc
 EndChar
 
@@ -43831,9 +43831,9 @@ SplineSet
  142 530 l 2
  142 562 140 571 128 571 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" one slash eight
-Ligature2: "'frac' Brueche 1" one fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction eight
+Ligature2: "'frac' Brueche 1" one slash eight
 Colour: ff9ccc
 EndChar
 
@@ -43892,9 +43892,9 @@ SplineSet
  569 19 568 45 528 65 c 2
  499 79 l 1
 EndSplineSet
-Ligature2: "'frac' Brueche 1" three slash eight
-Ligature2: "'frac' Brueche 1" three fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" three fraction eight
+Ligature2: "'frac' Brueche 1" three slash eight
 Colour: ff9ccc
 EndChar
 
@@ -43952,9 +43952,9 @@ SplineSet
  564 18 563 44 523 64 c 2
  494 78 l 1
 EndSplineSet
-Ligature2: "'frac' Brueche 1" five slash eight
-Ligature2: "'frac' Brueche 1" five fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five fraction eight
+Ligature2: "'frac' Brueche 1" five slash eight
 Colour: ff9ccc
 EndChar
 
@@ -44005,9 +44005,9 @@ SplineSet
  574 19 573 45 533 65 c 2
  504 79 l 1
 EndSplineSet
-Ligature2: "'frac' Brueche 1" seven slash eight
-Ligature2: "'frac' Brueche 1" seven fraction eight
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" seven fraction eight
+Ligature2: "'frac' Brueche 1" seven slash eight
 Colour: ff9ccc
 EndChar
 
@@ -44038,8 +44038,8 @@ SplineSet
  139 531 l 2
  139 563 137 572 125 572 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" one slash
 Ligature2: "'frac' Brueche 1" one fraction
+Ligature2: "'frac' Brueche 1" one slash
 Colour: ff9ccc
 EndChar
 
@@ -48453,8 +48453,8 @@ SplineSet
  161.7 431.3 161.5 421.3 161.3 409 c 1
  355 409 l 1
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" f f
 LCarets2: 1 261
+Ligature2: "'liga' Standardligaturen 1" f f
 EndChar
 
 StartChar: f_i
@@ -48505,8 +48505,8 @@ SplineSet
  455 421 452.6 357 451 318 c 0
  449 268 449 162 451 112 c 0
 EndSplineSet
-Ligature2: "'liga' Standardligaturen ohne TRK CRT AZE 1" f i
 LCarets2: 1 277
+Ligature2: "'liga' Standardligaturen ohne TRK CRT AZE 1" f i
 EndChar
 
 StartChar: f_l
@@ -48561,8 +48561,8 @@ SplineSet
  303.1 0.9 302.9 11.9 309 18 c 1
  367 21 376 24 378 103 c 0
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" f l
 LCarets2: 1 288
+Ligature2: "'liga' Standardligaturen 1" f l
 EndChar
 
 StartChar: f_f_i
@@ -48634,8 +48634,8 @@ SplineSet
  173.7 540.8 165.7 505.9 163 438 c 0
  162.8 432.2 162.6 424 162.4 414 c 1
 EndSplineSet
-Ligature2: "'liga' Standardligaturen ohne TRK CRT AZE 1" f f i
 LCarets2: 2 266 550
+Ligature2: "'liga' Standardligaturen ohne TRK CRT AZE 1" f f i
 EndChar
 
 StartChar: longs_t
@@ -48687,8 +48687,8 @@ SplineSet
  284 403 288 409 301 409 c 2
  345 409 l 1
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" longs t
 LCarets2: 1 265
+Ligature2: "'liga' Standardligaturen 1" longs t
 EndChar
 
 StartChar: .notdef
@@ -51993,8 +51993,8 @@ SplineSet
  379 382 378 383 378 388 c 2
  378 405 l 2
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" s t
 LCarets2: 1 357
+Ligature2: "'hlig' Historische Ligaturen 1" s t
 Colour: ff9ccc
 EndChar
 
@@ -52833,8 +52833,8 @@ SplineSet
  -231 510 -282 560 -296 645 c 1
  -269 657 l 1
 EndSplineSet
-Substitution2: "Substitution cap-Accents 1" breve.cap
 Substitution2: "'case' Versalformen 1" uni035C
+Substitution2: "Substitution cap-Accents 1" breve.cap
 EndChar
 
 StartChar: uni0304
@@ -60987,9 +60987,9 @@ SplineSet
  147 531 l 2
  147 563 145 572 133 572 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" one slash six
-Ligature2: "'frac' Brueche 1" one fraction six
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" one fraction six
+Ligature2: "'frac' Brueche 1" one slash six
 Colour: ff9ccc
 EndChar
 
@@ -61038,9 +61038,9 @@ SplineSet
  459 95 486 112 511 112 c 0
  608 112 618 33 618 16 c 0
 EndSplineSet
-Ligature2: "'frac' Brueche 1" five slash six
-Ligature2: "'frac' Brueche 1" five fraction six
 LCarets2: 2 0 0
+Ligature2: "'frac' Brueche 1" five fraction six
+Ligature2: "'frac' Brueche 1" five slash six
 Colour: ff9ccc
 EndChar
 
@@ -67564,8 +67564,8 @@ SplineSet
  452 444 l 1
  452 106 l 2
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" f j
 LCarets2: 1 296
+Ligature2: "'liga' Standardligaturen 1" f j
 EndChar
 
 StartChar: uni0360
@@ -67739,8 +67739,8 @@ SplineSet
  1076 54 1067 52 1062 48 c 0
  1015 10 960 -10 923 -10 c 0
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" Q u
 LCarets2: 1 708
+Ligature2: "'liga' Standardligaturen 1" Q u
 Colour: ff9ccc
 EndChar
 
@@ -67829,8 +67829,8 @@ SplineSet
  433 68 316 -10 239 -10 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" zero.cap.fitted
-Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 Substitution2: "'tnum' Tabellenziffern 1" zero
+Substitution2: "'zero' gestrichene Null 1" zero.slash.fitted
 Colour: ff00ff
 EndChar
 
@@ -72810,8 +72810,8 @@ SplineSet
  207 408 207 397 201 391 c 1
  158 385 151 377 176 341 c 2
 EndSplineSet
-Substitution2: "'sups' Hochgestellte 1" uni02E3
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2093
+Substitution2: "'sups' Hochgestellte 1" uni02E3
 EndChar
 
 StartChar: uni03D8
@@ -78751,10 +78751,10 @@ SplineSet
  109 56 183 14 228 14 c 0
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" eight.cap
-Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'onum' Minuskelziffern 1" eight.taboldstyle
-Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2088
+Substitution2: "'sups' Hochgestellte 1" uni2078
 EndChar
 
 StartChar: uniFFFD
@@ -79260,8 +79260,8 @@ SplineSet
  348.4 551.3 l 1
 EndSplineSet
 Substitution2: "'case' Versalformen Figures" zero.slash.cap
-Substitution2: "'sups' Hochgestellte 1" uni2070
 Substitution2: "'sinf' Wissenschaftliche Indices 1" uni2080
+Substitution2: "'sups' Hochgestellte 1" uni2070
 EndChar
 
 StartChar: uniE100
@@ -79436,9 +79436,9 @@ SplineSet
  131 246 109 176 109 146 c 0
  109 56 183 14 228 14 c 0
 EndSplineSet
-Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 Substitution2: "'pnum' Proportionalziffern 1" eight.fitted
 Substitution2: "'sups' Hochgestellte 1" uni2078
+Substitution2: "'tnum' Tabellenziffern 1" eight.taboldstyle
 EndChar
 
 StartChar: nine.oldstyle
@@ -79562,8 +79562,8 @@ SplineSet
  30 395 l 2
  30 403 34 409 47 409 c 2
 EndSplineSet
-Ligature2: "'liga' Standardligaturen 1" t t
 LCarets2: 1 306
+Ligature2: "'liga' Standardligaturen 1" t t
 EndChar
 
 StartChar: c_t
@@ -79611,8 +79611,8 @@ SplineSet
  282 31 317 57 347 100 c 1
  364 87 l 1
 EndSplineSet
-Ligature2: "'hlig' Historische Ligaturen 1" c t
 LCarets2: 1 407
+Ligature2: "'hlig' Historische Ligaturen 1" c t
 EndChar
 
 StartChar: uni27E6
@@ -79681,8 +79681,8 @@ SplineSet
  112 -10 31 69 31 209 c 0
  31 334 115 419 219 419 c 0
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 Substitution2: "'lnum' Versalziffern 1" zero
+Substitution2: "'pnum' Proportionalziffern 1" zero.oldstyle
 EndChar
 
 StartChar: one.taboldstyle
@@ -79708,8 +79708,8 @@ SplineSet
  106 1 106 11 112 17 c 1
  179 20 195 27 195 106 c 2
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 Substitution2: "'lnum' Versalziffern 1" one
+Substitution2: "'pnum' Proportionalziffern 1" one.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -79740,8 +79740,8 @@ SplineSet
  151 52 l 1
  281 52 l 2
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 Substitution2: "'lnum' Versalziffern 1" two
+Substitution2: "'pnum' Proportionalziffern 1" two.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -79773,8 +79773,8 @@ SplineSet
  247 157 311 244 311 293 c 0
  311 355 265 389 221 389 c 0
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 Substitution2: "'lnum' Versalziffern 1" three
+Substitution2: "'pnum' Proportionalziffern 1" three.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -79811,8 +79811,8 @@ SplineSet
  204 227.8 121.3 119.2 70 37 c 1
  274.5 37 l 1
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 Substitution2: "'lnum' Versalziffern 1" four
+Substitution2: "'pnum' Proportionalziffern 1" four.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -79843,8 +79843,8 @@ SplineSet
  159.5 -154 172.5 -183 210.5 -183 c 0
  270.5 -183 326.5 -103 326.5 -8 c 0
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 Substitution2: "'lnum' Versalziffern 1" five
+Substitution2: "'pnum' Proportionalziffern 1" five.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -79871,8 +79871,8 @@ SplineSet
  358 606 356 597 356 585 c 1
  220.9 534.4 157.3 431 131 339 c 1
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 Substitution2: "'lnum' Versalziffern 1" six
+Substitution2: "'pnum' Proportionalziffern 1" six.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -79898,8 +79898,8 @@ SplineSet
  189 -24 278 181 356 375 c 1
  154 375 l 2
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 Substitution2: "'lnum' Versalziffern 1" seven
+Substitution2: "'pnum' Proportionalziffern 1" seven.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -79962,8 +79962,8 @@ SplineSet
  106 -203 108 -194 108 -182 c 1
  243.1 -131.4 306.7 -28 333 64 c 1
 EndSplineSet
-Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 Substitution2: "'lnum' Versalziffern 1" nine
+Substitution2: "'pnum' Proportionalziffern 1" nine.oldstyle
 Colour: ff00ff
 EndChar
 
@@ -83098,8 +83098,8 @@ SplineSet
  435.5 281 435 249.5 435 219.5 c 0
  435 189.5 435.9 139 437 109 c 0
 EndSplineSet
-Ligature2: "'liga' Standardligaturen ohne TRK CRT AZE 1" longs i
 LCarets2: 1 279
+Ligature2: "'liga' Standardligaturen ohne TRK CRT AZE 1" longs i
 Colour: ff9ccc
 EndChar
 


### PR DESCRIPTION
The substantive change in this request is to `sfdnormalize.py`. It has been extended to normalize the order of feature-related directives specific to glyphs. Those directives are:

1. Position(2)
2. PairPos(2)
3. LCarets(2)
4. Ligature(2)
5. Substitution(2)
6. MultipleSubs(2)
7. AlternateSubs(2)

The lines will first be put into the relative order above, and within entries in alphanumeric sort order. (The order is taken from `sfd.c` in the FontForge source, but is otherwise arbitrary.) Each .sfd has been normalized with the new script, changing the order of feature entries. 

This normalized order is not all that different from the already imposed ordering of `OtfFeatName` directives. FontForge stores the former in (more or less) the order they were added, and maintains that order when reading them in. But the order itself has no semantic implication. When order is relevant to non-chaining feature subtable entries, it is due to the content of those entries (see end of section 4.e of the Adobe spec: https://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html#4.e ). (The data for chained rules are stored in the font headers rather than the individual glyphs entries.) 

The (implied) semantic irrelevance of directive order  can also be verified by inspection of `glyphcomp.c:comparelookupsubtable()` in the fontforge source, and by running `sfdcompare` on the Libertinus source file versions before and after normalization with this utility. I have done this and verified that the only "difference" reported relates to the currently empty `calt` table in some of the files. 

I am pushing this change in advance of another that should be coming in the next few days. The idea is to eliminate git differences that just trace to the order in which feature subtables are loaded so that future reviews can focus on substantial changes. 