### PR TITLE
Reduce side bearings on single quote

### DIFF
--- a/sources/LibertinusSerif-Regular.sfd
+++ b/sources/LibertinusSerif-Regular.sfd
@@ -21787,12 +21787,12 @@ EndChar
 
 StartChar: quoteright
 Encoding: 8217 8217 1051
-Width: 268
+Width: 197
 GlyphClass: 2
 Flags: MW
 LayerCount: 2
 Fore
-Refer: 254 44 N 1 0 0 1 25 603 2
+Refer: 254 44 N 1 0 0 1 7 603 2
 Colour: ff00ff
 EndChar
 

--- a/sources/LibertinusSerif-Regular.sfd
+++ b/sources/LibertinusSerif-Regular.sfd
@@ -5269,18 +5269,18 @@ EndChar
 
 StartChar: quotesingle
 Encoding: 39 39 253
-Width: 190
+Width: 156
 GlyphClass: 2
 Flags: MW
 LayerCount: 2
 Fore
 SplineSet
-79 426 m 1
- 79 426 53 585 53 594 c 0
- 53 616 74 644 104 644 c 0
- 130 644 139 627 139 611 c 0
- 139 595 106 430 106 430 c 1
- 79 426 l 1
+76 426 m 1
+ 76 426 50 585 50 594 c 0
+ 50 616 71 644 101 644 c 0
+ 127 644 136 627 136 611 c 0
+ 136 595 103 430 103 430 c 1
+ 76 426 l 1
 EndSplineSet
 EndChar
 


### PR DESCRIPTION
Closes #323.

This currently a WIP, but when it does land it will be a significant change to metrics, so I will probably delay merging this until after a few small fixes hit and a minor dot release happens first.

<details><summary>test code</summary>
<p>

```sile
\begin[papersize=500pt x 1000pt]{document}
\script[src=packages/rules]
\nofolios
\neverindent
\font[family=Libertinus Sans,size=5pt]
\begin{raggedright}
\begin{script}

local _c = io.open(".fontship/last-commit", "r")
newver = _c:read("*a"):gsub("\n", "")
io.close(_c)

function extant(face, weight, style)
  face = face:gsub(" ", "")
  local fname = string.format("Libertinus%s-%s%s.otf", face, weight, style)
  local f = io.open(fname, "r")
  if f then
    io.close(f)
    return fname
  end
end

function tonum(weight)
  if weight == "Bold" then
    return 800
  elseif weight == "Semibold" then
    return 600
  end
  return 400
end

faces = { "Serif", "Serif Display", "Sans", --[[ "Mono", "Math", --[["SerifInitials", "Keyboard" ]]}
weights = { "", "Bold", "Semibold" }
styles = { "", "Regular", "Italic" }

SILE.registerCommand("sample", function (options, _)
  options.size = "25pt"
  SILE.call("font", options, function ()
    local str = "C'è po'. C'era D'est L'o A'e Saint' Ant's."
    SILE.typesetter:typeset(str)
    --SILE.call("font", { features = "+smcp" }, { "\\f\\ (f) [f] {f}" })
  end)
  SILE.call("skip", { height = "4pt" })
  SILE.call("par")
end)

SILE.registerCommand("label", function (options, content)
  SILE.process(content)
  SILE.call("hfill")
  SILE.call("break")
end)

for _, face in ipairs(faces) do
  for _, weight in ipairs(weights) do
    for _, style in ipairs(styles) do
      local fname = extant(face, weight, style)
      if fname then
        local disp = string.format("Libertinus %s – %s %s v", face, weight, style)
        SILE.call("label", {}, { disp .. "7.000" })
        SILE.call("sample", { family = "Libertinus "..face, weight = tonum(weight), style = style })
        SILE.call("label", {}, { disp .. newver })
        SILE.call("sample", { filename = fname })
        SILE.call("hrule", { width = "100%lw" })
        SILE.call("skip", { height = "4pt" })
      end
    end
  end
end

\end{script}
\end{raggedright}
\end{document}
```

</p>
</details>

![image](https://user-images.githubusercontent.com/173595/90834701-89170780-e353-11ea-80b4-dd40532be183.png)

@rriemann What do you think of this? (Besides the preview above you can download artifacts from the Actions tab of this PR to test for yourself.)