### PR TITLE
Add ogonek and cedilla anchors for dotlessi in Serif-Italic

### DIFF
--- a/sources/LibertinusSerif-Italic.sfd
+++ b/sources/LibertinusSerif-Italic.sfd
@@ -1,4 +1,4 @@
-SplineFontDB: 3.2
+SplineFontDB: 3.0
 FontName: LibertinusSerif-Italic
 FullName: Libertinus Serif Italic
 FamilyName: Libertinus Serif
@@ -10364,6 +10364,8 @@ Encoding: 305 305 421
 Width: 276
 GlyphClass: 2
 Flags: MW
+AnchorPoint: "cedilla" 137 12 basechar 0
+AnchorPoint: "ogonek" 209 10 basechar 0
 AnchorPoint: "above" 267 645 basechar 0
 AnchorPoint: "below" 139 -108 basechar 0
 LayerCount: 2


### PR DESCRIPTION
In Serif Italic, the `dotlessi` glyph was lacking cedilla and ogonek anchors, which led to a suboptimal output:

![grafik](https://github.com/user-attachments/assets/7fc617c3-3212-4405-b039-573bf1ff8271)


I have copied the cedilla and ogonek anchors from the `i` base glyph to `dotlessi`:

![grafik](https://github.com/user-attachments/assets/ec071c67-8b7e-4302-9a29-29e4cb79ef0f)


@alerque, the change in `SplineFontDB` is due to `fontship make normalize`. I suppose that should change?
